### PR TITLE
fix: route password reset through auth callback for PKCE flow

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -22,7 +22,7 @@ export default function ForgotPasswordPage() {
     setError("");
 
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/update-password`,
+      redirectTo: `${window.location.origin}/auth/callback?next=/update-password`,
     });
 
     if (error) {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,22 +1,40 @@
-import { createClient } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
   const next = searchParams.get("next") ?? "/tournaments";
 
+  const redirectUrl = next.startsWith("/") ? `${origin}${next}` : `${origin}/tournaments`;
+
   if (code) {
-    const supabase = await createClient();
+    const response = NextResponse.redirect(redirectUrl);
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              response.cookies.set(name, value, options);
+            });
+          },
+        },
+      }
+    );
+
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {
-      // Check if this is a password reset flow by looking at the 'next' param
-      const redirectUrl = next.startsWith("/") ? `${origin}${next}` : next;
-      return NextResponse.redirect(redirectUrl);
+      return response;
     }
   }
 
-  // Return the user to an error page with instructions
+  // Return the user to the login page with an error indicator
   return NextResponse.redirect(`${origin}/login?error=auth_callback_error`);
 }


### PR DESCRIPTION
The redirectTo URL must go through /auth/callback to exchange the code for a session before reaching /update-password. Also rewrote the callback route to properly propagate cookies on the redirect response using NextRequest/NextResponse directly.