### PR TITLE
fix: allow admins to update all predictions when scoring matches

### DIFF
--- a/supabase/bootstrap.sql
+++ b/supabase/bootstrap.sql
@@ -513,6 +513,7 @@ CREATE POLICY "Users can insert their own predictions"
     ON public.predictions FOR INSERT
     WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can update own predictions" ON public.predictions;
 DROP POLICY IF EXISTS "Users can update their own predictions" ON public.predictions;
 CREATE POLICY "Users can update their own predictions"
     ON public.predictions FOR UPDATE

--- a/supabase/migrations/20260201000000_fix_predictions_admin_update_policy.sql
+++ b/supabase/migrations/20260201000000_fix_predictions_admin_update_policy.sql
@@ -1,0 +1,13 @@
+-- Fix predictions UPDATE policy to allow admins to score all predictions
+-- This aligns the migration with bootstrap.sql
+--
+-- Problem: When scoring a match, the admin could only update their own predictions
+-- because the RLS policy blocked updates to other users' predictions.
+-- This caused points_earned to only be set for the admin's predictions.
+
+DROP POLICY IF EXISTS "Users can update own predictions" ON predictions;
+DROP POLICY IF EXISTS "Users can update their own predictions" ON predictions;
+
+CREATE POLICY "Users can update their own predictions"
+    ON public.predictions FOR UPDATE
+    USING (auth.uid() = user_id OR public.is_admin(auth.uid()));


### PR DESCRIPTION
## Summary

- Fixes bug where match scoring only updated the admin's own predictions, not all users' predictions
- Added migration to update the predictions UPDATE RLS policy to include admin check
- Aligned bootstrap.sql to drop both old policy name variants for clean database setup

## Problem

When an admin scored a match via `/api/matches/[matchId]/score`, the `points_earned` field was only being updated for the admin's own predictions. Other users' predictions were silently skipped because the RLS UPDATE policy only allowed `auth.uid() = user_id`.

## Solution

Added `OR public.is_admin(auth.uid())` to the predictions UPDATE policy, allowing admins to update any user's prediction when scoring matches. This aligns the migrations with the existing bootstrap.sql policy.

## Test plan

- [ ] Apply migration to development database
- [ ] Have a non-admin user submit a prediction for a match
- [ ] Score the match as an admin user
- [ ] Verify all predictions for that match have `points_earned` updated
- [ ] Check tournament rankings reflect the correct total points
