### PR TITLE
feat: UI streamlining with sports-editorial design system

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "github@claude-plugins-official": true
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,12 @@
       "Bash(git add:*)",
       "Bash(ls:*)",
       "Bash(find:*)",
-      "Bash(done)"
+      "Bash(done)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)",
+      "mcp__plugin_playwright_playwright__browser_navigate",
+      "mcp__plugin_playwright_playwright__browser_take_screenshot",
+      "mcp__plugin_playwright_playwright__browser_resize"
     ],
     "deny": [],
     "ask": []

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -55,27 +55,49 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary p-4 relative">
-      <div className="absolute top-4 right-4">
-        <LanguageSwitcher />
+    <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
+      {/* Background: same spotlight as landing */}
+      <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--primary)/0.08)_0%,transparent_70%)]" />
+
+      <div className="absolute top-4 right-4 z-10">
+        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
+          <LanguageSwitcher />
+        </div>
       </div>
-      <Card className="w-full max-w-md">
+
+      <Card className="w-full max-w-md relative animate-scale-in">
         <CardHeader>
-          <CardTitle className="text-2xl">{t('title')}</CardTitle>
+          <CardTitle className="font-display text-3xl uppercase tracking-tight">{t('title')}</CardTitle>
           <CardDescription>
             {t('subtitle')}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Passkey Login Section */}
-          <div className="space-y-4">
-            <PasskeyLoginButton
-              onSuccess={() => {
-                router.push("/tournaments");
-                router.refresh();
-              }}
+          {/* Shared Email Field */}
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">
+              {t('emailLabel')}
+            </label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@email.com"
+              required
+              autoComplete="email"
             />
           </div>
+
+          {/* Passkey Login Section */}
+          <PasskeyLoginButton
+            email={email}
+            onSuccess={() => {
+              router.push("/tournaments");
+              router.refresh();
+            }}
+          />
 
           {/* Divider */}
           <div className="relative">
@@ -89,21 +111,8 @@ export default function LoginPage() {
             </div>
           </div>
 
-          {/* Email/Password Login Section */}
+          {/* Password Login Section */}
           <form onSubmit={handleLogin} className="space-y-4">
-            <div className="space-y-2">
-              <label htmlFor="email" className="text-sm font-medium">
-                {t('emailLabel')}
-              </label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="your@email.com"
-                required
-              />
-            </div>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <label htmlFor="password" className="text-sm font-medium">

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -49,13 +49,20 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary p-4 relative">
-      <div className="absolute top-4 right-4">
-        <LanguageSwitcher />
+    <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
+      {/* Background: same spotlight as landing */}
+      <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--primary)/0.08)_0%,transparent_70%)]" />
+
+      <div className="absolute top-4 right-4 z-10">
+        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
+          <LanguageSwitcher />
+        </div>
       </div>
-      <Card className="w-full max-w-md">
+
+      <Card className="w-full max-w-md relative animate-scale-in">
         <CardHeader>
-          <CardTitle className="text-2xl">{t('title')}</CardTitle>
+          <CardTitle className="font-display text-3xl uppercase tracking-tight">{t('title')}</CardTitle>
           <CardDescription>
             {t('subtitle')}
           </CardDescription>

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,23 @@
     --chart-3: 199 100% 29%; /* #006494 */
     --chart-4: 202 100% 16%; /* #003554 */
     --chart-5: 200 75% 8%;   /* #051923 */
+
+    /* Semantic status colors - Light Mode */
+    --success: 142 71% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+    --info: 202 95% 41%;
+    --info-foreground: 0 0% 100%;
+
+    /* Achievement / podium colors */
+    --gold: 45 93% 47%;
+    --silver: 210 14% 53%;
+    --bronze: 30 61% 50%;
+
+    /* Depth layers */
+    --surface-elevated: 0 0% 100%;
+    --surface-sunken: 200 60% 97%;
   }
 
   .dark {
@@ -96,6 +113,23 @@
     --chart-3: 199 100% 29%; /* #006494 */
     --chart-4: 202 100% 16%; /* #003554 */
     --chart-5: 200 75% 8%;   /* #051923 */
+
+    /* Semantic status colors - Dark Mode */
+    --success: 142 71% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+    --info: 200 100% 49%;
+    --info-foreground: 200 75% 8%;
+
+    /* Achievement / podium colors */
+    --gold: 45 93% 47%;
+    --silver: 210 14% 63%;
+    --bronze: 30 61% 50%;
+
+    /* Depth layers */
+    --surface-elevated: 202 100% 19%;
+    --surface-sunken: 200 75% 6%;
   }
 }
 
@@ -105,5 +139,86 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image: radial-gradient(hsl(var(--foreground) / 0.03) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  html {
+    scroll-behavior: smooth;
+  }
+  ::selection {
+    background-color: hsl(var(--primary) / 0.2);
+    color: hsl(var(--foreground));
+  }
+  *:focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  }
+
+  /* Typography: display font for headings */
+  h1, h2, h3 {
+    font-family: var(--font-display), sans-serif;
+  }
+}
+
+/* === Animation System === */
+@layer utilities {
+  /* Entrance animations */
+  .animate-fade-in {
+    animation: fade-in 0.5s ease-out both;
+  }
+  .animate-slide-up {
+    animation: slide-up 0.5s ease-out both;
+  }
+  .animate-scale-in {
+    animation: scale-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* Score pop with spring easing */
+  .animate-score-pop {
+    animation: score-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  /* Live match pulse */
+  .animate-pulse-live {
+    animation: pulse-live 2s ease-in-out infinite;
+  }
+
+  /* Stagger delays for cascading entrance */
+  .stagger-1 { animation-delay: 0.05s; }
+  .stagger-2 { animation-delay: 0.10s; }
+  .stagger-3 { animation-delay: 0.15s; }
+  .stagger-4 { animation-delay: 0.20s; }
+  .stagger-5 { animation-delay: 0.25s; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes score-pop {
+  from { opacity: 0; transform: scale(0.5); }
+  60%  { transform: scale(1.1); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pulse-live {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+
+/* Mobile: disable background-attachment fixed if used */
+@media (max-width: 767px) {
+  body {
+    background-attachment: scroll;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,20 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Oswald } from "next/font/google";
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-body",
+});
+
+const oswald = Oswald({
+  subsets: ["latin"],
+  variable: "--font-display",
+});
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('metadata.home');
@@ -27,7 +35,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={`${inter.variable} ${oswald.variable} ${inter.className}`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <NextIntlClientProvider messages={messages} locale={locale}>
             {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { getTranslations } from 'next-intl/server';
 import { LanguageSwitcher } from "@/components/layout/language-switcher";
+import { Target, Users, Trophy } from "lucide-react";
 
 export default async function Home() {
   const t = await getTranslations('home');
@@ -16,26 +17,57 @@ export default async function Home() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary relative">
-      <div className="absolute top-4 right-4">
-        <LanguageSwitcher />
+    <div className="min-h-screen flex items-center justify-center relative overflow-hidden">
+      {/* Background: radial spotlight + dot texture from globals */}
+      <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--primary)/0.08)_0%,transparent_70%)]" />
+
+      {/* Language Switcher */}
+      <div className="absolute top-4 right-4 z-10">
+        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
+          <LanguageSwitcher />
+        </div>
       </div>
-      <div className="text-center space-y-6 p-8">
-        <h1 className="text-6xl font-bold tracking-tight">
+
+      {/* Content */}
+      <div className="relative text-center space-y-8 p-8 max-w-2xl mx-auto animate-fade-in">
+        <h1 className="font-display text-7xl md:text-8xl font-bold uppercase tracking-tighter">
           {t('title')}
         </h1>
-        <p className="text-xl text-muted-foreground max-w-md mx-auto">
+        <p className="text-xl md:text-2xl font-medium bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent">
           {t('subtitle')}
         </p>
-        <p className="text-muted-foreground max-w-md mx-auto">
+        <p className="text-muted-foreground max-w-md mx-auto text-lg">
           {t('description')}
         </p>
+
+        {/* Feature Pills */}
+        <div className="flex flex-wrap gap-3 justify-center">
+          <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-sunken border border-border text-sm font-medium">
+            <Target className="h-4 w-4 text-primary" />
+            {t('features.predict')}
+          </span>
+          <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-sunken border border-border text-sm font-medium">
+            <Users className="h-4 w-4 text-primary" />
+            {t('features.compete')}
+          </span>
+          <span className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-sunken border border-border text-sm font-medium">
+            <Trophy className="h-4 w-4 text-primary" />
+            {t('features.leaderboard')}
+          </span>
+        </div>
+
+        {/* CTAs */}
         <div className="flex gap-4 justify-center pt-4">
           <Link href="/signup">
-            <Button size="lg">{t('getStarted')}</Button>
+            <Button size="lg" className="text-lg px-8 transition-all duration-200 hover:scale-105 hover:shadow-lg">
+              {t('getStarted')}
+            </Button>
           </Link>
           <Link href="/login">
-            <Button size="lg" variant="outline">{t('login')}</Button>
+            <Button size="lg" variant="outline" className="text-lg px-8 transition-all duration-200 hover:scale-105">
+              {t('login')}
+            </Button>
           </Link>
         </div>
       </div>

--- a/components/auth/passkey/passkey-login-button.tsx
+++ b/components/auth/passkey/passkey-login-button.tsx
@@ -3,13 +3,12 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Fingerprint, Loader2 } from "lucide-react";
 import { authenticateWithPasskey, isPasskeySupported } from "@/lib/webauthn/client";
 import { useTranslations } from 'next-intl';
 
 interface PasskeyLoginButtonProps {
+  email: string;
   onSuccess?: () => void;
   onError?: (error: string) => void;
   className?: string;
@@ -18,16 +17,16 @@ interface PasskeyLoginButtonProps {
 /**
  * Component for logging in with a passkey
  *
- * Includes email input and passkey authentication button
+ * Receives email from parent (shared with password form) and triggers passkey authentication
  */
 export function PasskeyLoginButton({
+  email,
   onSuccess,
   onError,
   className,
 }: PasskeyLoginButtonProps) {
   const t = useTranslations('auth.passkeys');
   const tCommon = useTranslations('common');
-  const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -85,25 +84,7 @@ export function PasskeyLoginButton({
   }
 
   return (
-    <div className={`space-y-4 ${className}`}>
-      <div className="space-y-2">
-        <Label htmlFor="passkey-email">{tCommon('labels.emailAddress')}</Label>
-        <Input
-          id="passkey-email"
-          type="email"
-          placeholder="your@email.com"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              handleAuthenticate();
-            }
-          }}
-          disabled={isLoading}
-          autoComplete="email webauthn"
-        />
-      </div>
-
+    <div className={`space-y-3 ${className || ""}`}>
       <Button
         onClick={handleAuthenticate}
         disabled={isLoading || !email}

--- a/components/layout/app-nav.tsx
+++ b/components/layout/app-nav.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from 'next-intl';
-import { Button } from "@/components/ui/button";
 import { UserNav } from "@/components/profile/user-nav";
 import { MobileNav } from "./mobile-nav";
 import { LanguageSwitcher } from "./language-switcher";
 import { User } from "@/types/database";
 import { createClient } from "@/lib/supabase/client";
+import { Shield } from "lucide-react";
 
 interface AppNavProps {
   user: User | null;
@@ -17,6 +17,7 @@ interface AppNavProps {
 export function AppNav({ user }: AppNavProps) {
   const t = useTranslations('common');
   const router = useRouter();
+  const pathname = usePathname();
   const supabase = createClient();
 
   async function handleSignOut() {
@@ -25,31 +26,62 @@ export function AppNav({ user }: AppNavProps) {
     router.refresh();
   }
 
+  const isActive = (href: string) => pathname === href || pathname.startsWith(href + "/");
+
   return (
-    <nav className="border-b">
-      <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-        <Link href="/tournaments" className="text-2xl font-bold">
+    <nav className="border-b bg-background/80 backdrop-blur-md sticky top-0 z-50">
+      <div className="container mx-auto px-4 py-3 flex justify-between items-center">
+        <Link href="/tournaments" className="font-display text-2xl font-bold uppercase tracking-tight">
           {t('appName')}
         </Link>
 
         {/* Desktop Navigation */}
-        <div className="hidden md:flex gap-4 items-center">
+        <div className="hidden md:flex gap-1 items-center">
           <LanguageSwitcher />
-          <Link href="/tournaments">
-            <Button variant="ghost">{t('navigation.tournaments')}</Button>
+          <Link
+            href="/tournaments"
+            className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+              isActive("/tournaments") && !pathname.includes("/manage")
+                ? "text-primary border-b-2 border-primary"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {t('navigation.tournaments')}
           </Link>
           {user?.is_admin && (
-            <>
-              <Link href="/tournaments/manage">
-                <Button variant="ghost">{t('navigation.manageTournaments')}</Button>
+            <div className="flex items-center gap-1 ml-2 bg-muted/50 rounded-lg px-1 py-0.5">
+              <Shield className="h-3.5 w-3.5 text-muted-foreground" />
+              <Link
+                href="/tournaments/manage"
+                className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                  isActive("/tournaments/manage")
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {t('navigation.manageTournaments')}
               </Link>
-              <Link href="/teams">
-                <Button variant="ghost">{t('navigation.manageTeams')}</Button>
+              <Link
+                href="/teams"
+                className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                  isActive("/teams")
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {t('navigation.manageTeams')}
               </Link>
-              <Link href="/admin/users">
-                <Button variant="ghost">{t('navigation.userManagement')}</Button>
+              <Link
+                href="/admin/users"
+                className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                  isActive("/admin/users")
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {t('navigation.userManagement')}
               </Link>
-            </>
+            </div>
           )}
           {user && <UserNav user={user} />}
         </div>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useTranslations } from 'next-intl';
 import { Button } from "@/components/ui/button";
-import { Menu, X } from "lucide-react";
+import { Menu, X, Trophy, Settings, Users, Shield, UserCircle, LogOut } from "lucide-react";
 import { LanguageSwitcher } from "./language-switcher";
 import { User } from "@/types/database";
 
@@ -37,21 +37,21 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
       {/* Mobile Menu Overlay */}
       {isOpen && (
         <div
-          className="fixed inset-0 bg-background/80 backdrop-blur-sm z-40 md:hidden"
+          className="fixed inset-0 bg-background/60 backdrop-blur-sm z-40 md:hidden"
           onClick={closeMenu}
         />
       )}
 
       {/* Mobile Menu Sidebar */}
       <div
-        className={`fixed top-0 right-0 h-full w-64 bg-background border-l z-50 transform transition-transform duration-200 ease-in-out md:hidden ${
+        className={`fixed top-0 right-0 h-full w-72 bg-background/95 backdrop-blur-xl border-l z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b">
-            <span className="font-semibold">{t('appName')}</span>
+            <span className="font-display font-bold uppercase tracking-tight">{t('appName')}</span>
             <button onClick={closeMenu} aria-label="Close menu">
               <X className="h-5 w-5" />
             </button>
@@ -59,31 +59,41 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
 
           {/* Menu Items */}
           <nav className="flex-1 overflow-y-auto">
-            <div className="flex flex-col p-4 space-y-2">
-              <div className="mb-2">
+            <div className="flex flex-col p-4 space-y-1">
+              <div className="mb-3">
                 <LanguageSwitcher />
               </div>
 
               <Link href="/tournaments" onClick={closeMenu}>
-                <Button variant="ghost" className="w-full justify-start">
+                <Button variant="ghost" className="w-full justify-start gap-3">
+                  <Trophy className="h-4 w-4" />
                   {t('navigation.tournaments')}
                 </Button>
               </Link>
 
               {user?.is_admin && (
                 <>
+                  <div className="pt-3 pb-1 px-3">
+                    <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      <Shield className="h-3 w-3" />
+                      {t('navigation.admin')}
+                    </div>
+                  </div>
                   <Link href="/tournaments/manage" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start">
+                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                      <Settings className="h-4 w-4" />
                       {t('navigation.manageTournaments')}
                     </Button>
                   </Link>
                   <Link href="/teams" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start">
+                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                      <Users className="h-4 w-4" />
                       {t('navigation.manageTeams')}
                     </Button>
                   </Link>
                   <Link href="/admin/users" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start">
+                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                      <UserCircle className="h-4 w-4" />
                       {t('navigation.userManagement')}
                     </Button>
                   </Link>
@@ -92,20 +102,22 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
 
               {user && (
                 <>
-                  <div className="border-t my-2" />
+                  <div className="border-t my-3" />
                   <Link href="/profile" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start">
+                    <Button variant="ghost" className="w-full justify-start gap-3">
+                      <UserCircle className="h-4 w-4" />
                       {t('navigation.account')}
                     </Button>
                   </Link>
                   <Button
                     variant="ghost"
-                    className="w-full justify-start text-destructive hover:text-destructive"
+                    className="w-full justify-start gap-3 text-destructive hover:text-destructive"
                     onClick={() => {
                       closeMenu();
                       onSignOut();
                     }}
                   >
+                    <LogOut className="h-4 w-4" />
                     {t('navigation.signOut')}
                   </Button>
                 </>

--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { TeamBadge } from "@/components/teams/team-badge";
 import { Badge } from "@/components/ui/badge";
 import { formatLocalDateTime } from "@/lib/utils/date";
+import { Zap } from "lucide-react";
 import Link from "next/link";
 
 interface MatchCardProps {
@@ -18,9 +19,14 @@ export function MatchCard({ match }: MatchCardProps) {
   const isCompleted = match.status === "completed";
   const isLive = match.status === "in_progress";
 
+  const homeWins = isCompleted && match.home_score !== null && match.away_score !== null && match.home_score > match.away_score;
+  const awayWins = isCompleted && match.home_score !== null && match.away_score !== null && match.away_score > match.home_score;
+
   return (
     <Link href={`/${match.tournament_id}/matches/${match.id}`}>
-      <Card className={`transition-colors hover:bg-muted/50 cursor-pointer ${isLive ? "border-green-500 border-2" : ""}`}>
+      <Card className={`transition-all duration-200 hover:bg-muted/50 hover:-translate-y-0.5 cursor-pointer ${
+        isLive ? "border-success border-2 shadow-[0_0_15px_hsl(var(--success)/0.15)]" : ""
+      }`}>
         <CardContent className="p-6">
         <div className="space-y-4">
           {/* Match Info */}
@@ -30,14 +36,15 @@ export function MatchCard({ match }: MatchCardProps) {
                 {formatLocalDateTime(match.match_date)}
               </span>
               {match.multiplier > 1 && (
-                <Badge variant="outline" className="text-orange-500 border-orange-500">
+                <Badge variant="outline" className="text-warning border-warning">
+                  <Zap className="h-3 w-3 mr-0.5" />
                   {match.multiplier}x
                 </Badge>
               )}
             </div>
             <Badge
               variant={isLive ? "default" : "outline"}
-              className={isLive ? "bg-green-500" : ""}
+              className={isLive ? "bg-success animate-pulse-live" : ""}
             >
               {t(match.status as 'scheduled' | 'in_progress' | 'completed' | 'postponed' | 'cancelled')}
             </Badge>
@@ -45,12 +52,12 @@ export function MatchCard({ match }: MatchCardProps) {
 
           {/* Teams and Score */}
           <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
+            <div className={`flex-1 ${homeWins ? "font-semibold" : ""}`}>
               <TeamBadge team={match.home_team} size="md" showName={true} />
             </div>
 
             {isCompleted && match.home_score !== null && match.away_score !== null ? (
-              <div className="flex items-center gap-3 text-2xl font-bold">
+              <div className="flex items-center gap-3 font-display text-3xl font-bold animate-score-pop">
                 <span>{match.home_score}</span>
                 <span className="text-muted-foreground">:</span>
                 <span>{match.away_score}</span>
@@ -61,7 +68,7 @@ export function MatchCard({ match }: MatchCardProps) {
               </div>
             )}
 
-            <div className="flex-1 flex justify-end">
+            <div className={`flex-1 flex justify-end ${awayWins ? "font-semibold" : ""}`}>
               <TeamBadge team={match.away_team} size="md" showName={true} />
             </div>
           </div>

--- a/components/matches/match-detail-view.tsx
+++ b/components/matches/match-detail-view.tsx
@@ -6,6 +6,7 @@ import { TeamBadge } from "@/components/teams/team-badge";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatLocalDateTime } from "@/lib/utils/date";
+import { Zap } from "lucide-react";
 import { useTranslations } from 'next-intl';
 
 interface PredictionWithUser extends Prediction {
@@ -32,11 +33,11 @@ export function MatchDetailView({
   const getStatusColor = () => {
     switch (match.status) {
       case "completed":
-        return "bg-blue-500";
+        return "bg-info";
       case "in_progress":
-        return "bg-green-500";
+        return "bg-success";
       case "cancelled":
-        return "bg-red-500";
+        return "bg-destructive";
       default:
         return "";
     }
@@ -50,14 +51,14 @@ export function MatchDetailView({
   });
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-fade-in">
       {/* Match Summary Card */}
-      <Card className={isLive ? "border-green-500 border-2" : ""}>
+      <Card className={isLive ? "border-success border-2 shadow-[0_0_15px_hsl(var(--success)/0.15)]" : ""}>
         <CardHeader>
           <div className="flex justify-between items-center">
             <Badge
               variant={isLive || isCompleted ? "default" : "outline"}
-              className={getStatusColor()}
+              className={`${getStatusColor()} ${isLive ? "animate-pulse-live" : ""}`}
             >
               {t(`status.${match.status}`)}
             </Badge>
@@ -73,7 +74,7 @@ export function MatchDetailView({
             {isCompleted &&
             match.home_score !== null &&
             match.away_score !== null ? (
-              <div className="flex items-center gap-4 text-4xl font-bold">
+              <div className="flex items-center gap-4 font-display text-4xl font-bold animate-score-pop">
                 <span>{match.home_score}</span>
                 <span className="text-muted-foreground">:</span>
                 <span>{match.away_score}</span>
@@ -107,7 +108,10 @@ export function MatchDetailView({
               <p className="text-sm text-muted-foreground">{t('details.multiplier')}</p>
               <p className="font-medium text-lg">
                 {match.multiplier > 1 ? (
-                  <span className="text-orange-500">{match.multiplier}x</span>
+                  <span className="text-warning flex items-center justify-center gap-1">
+                    <Zap className="h-4 w-4" />
+                    {match.multiplier}x
+                  </span>
                 ) : (
                   `${match.multiplier}x`
                 )}
@@ -150,10 +154,10 @@ export function MatchDetailView({
 
       {/* Scoring Info Card */}
       {match.multiplier > 1 && (
-        <Card className="border-orange-200 bg-orange-50 dark:bg-orange-950/20 dark:border-orange-900">
+        <Card className="border-warning/30 bg-warning/5">
           <CardContent className="py-4">
-            <div className="flex items-center gap-2 text-orange-700 dark:text-orange-400">
-              <span className="text-lg">⚡</span>
+            <div className="flex items-center gap-2 text-warning">
+              <Zap className="h-5 w-5" />
               <p className="text-sm">
                 {t('details.multiplierNote', { multiplier: match.multiplier })}
               </p>
@@ -228,7 +232,7 @@ function PredictionRow({
         {showPrediction ? (
           <>
             <div className="text-center">
-              <p className="text-lg font-bold">
+              <p className="text-lg font-bold font-display">
                 {prediction.predicted_home_score} :{" "}
                 {prediction.predicted_away_score}
               </p>
@@ -239,9 +243,9 @@ function PredictionRow({
                   variant={prediction.points_earned > 0 ? "default" : "outline"}
                   className={
                     prediction.points_earned >= 3 * match.multiplier
-                      ? "bg-green-500"
+                      ? "bg-success"
                       : prediction.points_earned > 0
-                      ? "bg-blue-500"
+                      ? "bg-info"
                       : ""
                   }
                 >

--- a/components/predictions/prediction-form.tsx
+++ b/components/predictions/prediction-form.tsx
@@ -7,7 +7,9 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { TeamBadge } from "@/components/teams/team-badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { formatLocalDateTime, isPastDate } from "@/lib/utils/date";
+import { Check, Lock } from "lucide-react";
 
 interface PredictionFormProps {
   match: MatchWithTeams;
@@ -20,7 +22,7 @@ interface PredictionFormProps {
 
 export function PredictionForm({ match, existingPrediction, onSubmit }: PredictionFormProps) {
   const t = useTranslations('predictions');
-  
+
   const [homeScore, setHomeScore] = useState(
     existingPrediction?.predicted_home_score?.toString() ?? ""
   );
@@ -31,10 +33,11 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
 
   const isPastMatchDate = isPastDate(match.match_date);
   const isCompleted = match.status === "completed";
+  const isLocked = isPastMatchDate || isCompleted;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!homeScore || !awayScore || isPastMatchDate) return;
+    if (!homeScore || !awayScore || isLocked) return;
 
     setIsSubmitting(true);
     try {
@@ -45,11 +48,30 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
   };
 
   return (
-    <Card>
+    <Card className={isLocked ? "opacity-60" : ""}>
       <CardHeader>
-        <CardTitle className="text-base">
-          {formatLocalDateTime(match.match_date)}
-        </CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">
+            {formatLocalDateTime(match.match_date)}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            {match.round && (
+              <Badge variant="outline" className="text-xs">{match.round}</Badge>
+            )}
+            {existingPrediction && !isLocked && (
+              <Badge variant="outline" className="text-success border-success">
+                <Check className="h-3 w-3 mr-1" />
+                {t('form.predicted')}
+              </Badge>
+            )}
+            {isLocked && (
+              <Badge variant="outline" className="text-muted-foreground">
+                <Lock className="h-3 w-3 mr-1" />
+                {t('form.locked')}
+              </Badge>
+            )}
+          </div>
+        </div>
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
@@ -65,19 +87,19 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
                 max="99"
                 value={homeScore}
                 onChange={(e) => setHomeScore(e.target.value)}
-                disabled={isPastMatchDate || isCompleted || isSubmitting}
-                className="w-16 text-center"
+                disabled={isLocked || isSubmitting}
+                className="w-20 text-center text-2xl font-display font-bold bg-surface-sunken"
                 placeholder="0"
               />
-              <span className="text-muted-foreground">:</span>
+              <span className="text-muted-foreground font-bold">:</span>
               <Input
                 type="number"
                 min="0"
                 max="99"
                 value={awayScore}
                 onChange={(e) => setAwayScore(e.target.value)}
-                disabled={isPastMatchDate || isCompleted || isSubmitting}
-                className="w-16 text-center"
+                disabled={isLocked || isSubmitting}
+                className="w-20 text-center text-2xl font-display font-bold bg-surface-sunken"
                 placeholder="0"
               />
             </div>
@@ -86,22 +108,18 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
               <TeamBadge team={match.away_team} size="sm" showName={true} />
             </div>
           </div>
-
-          {match.round && (
-            <div className="text-center text-sm text-muted-foreground">
-              {match.round}
-            </div>
-          )}
         </CardContent>
-        <CardFooter>
-          <Button
-            type="submit"
-            className="w-full"
-            disabled={!homeScore || !awayScore || isPastMatchDate || isCompleted || isSubmitting}
-          >
-            {isSubmitting ? t('form.saving') : existingPrediction ? t('form.updatePrediction') : t('form.submitPrediction')}
-          </Button>
-        </CardFooter>
+        {!isLocked && (
+          <CardFooter>
+            <Button
+              type="submit"
+              className="w-full transition-colors"
+              disabled={!homeScore || !awayScore || isSubmitting}
+            >
+              {isSubmitting ? t('form.saving') : existingPrediction ? t('form.updatePrediction') : t('form.submitPrediction')}
+            </Button>
+          </CardFooter>
+        )}
       </form>
     </Card>
   );

--- a/components/predictions/prediction-result-card.tsx
+++ b/components/predictions/prediction-result-card.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { TeamBadge } from "@/components/teams/team-badge";
 import { formatLocalDateTime } from "@/lib/utils/date";
-import { Trophy, Target, TrendingUp } from "lucide-react";
+import { Trophy, Target, TrendingUp, Sparkles, Zap } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 interface PredictionResultCardProps {
@@ -19,28 +19,24 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
   const multiplier = match.multiplier;
 
   // Determine badge variant and icon based on points
-  let badgeVariant: "default" | "secondary" | "outline" = "outline";
   let PointIcon = Target;
   let badgeClass = "";
 
   if (pointsEarned === 3 * multiplier) {
     // Exact score
-    badgeVariant = "default";
-    PointIcon = Trophy;
-    badgeClass = "bg-green-600 hover:bg-green-700 text-white";
+    PointIcon = Sparkles;
+    badgeClass = "bg-success hover:bg-success text-success-foreground";
   } else if (pointsEarned === 2 * multiplier) {
     // Correct difference
-    badgeVariant = "secondary";
     PointIcon = TrendingUp;
-    badgeClass = "bg-blue-600 hover:bg-blue-700 text-white";
+    badgeClass = "bg-info hover:bg-info text-info-foreground";
   } else if (pointsEarned === 1 * multiplier) {
     // Correct winner
-    badgeVariant = "secondary";
-    PointIcon = Target;
-    badgeClass = "bg-amber-600 hover:bg-amber-700 text-white";
+    PointIcon = Trophy;
+    badgeClass = "bg-warning hover:bg-warning text-warning-foreground";
   } else {
     // No points
-    badgeClass = "bg-gray-500 hover:bg-gray-600 text-white";
+    badgeClass = "bg-muted hover:bg-muted text-muted-foreground";
   }
 
   return (
@@ -52,11 +48,12 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
           </CardTitle>
           <div className="flex items-center gap-2">
             {multiplier > 1 && (
-              <Badge variant="outline" className="text-xs bg-amber-500/10 border-amber-500/20 text-amber-700 dark:text-amber-500">
-                ×{multiplier}
+              <Badge variant="outline" className="text-xs text-warning border-warning">
+                <Zap className="h-3 w-3 mr-0.5" />
+                {multiplier}x
               </Badge>
             )}
-            <Badge variant={badgeVariant} className={`flex items-center gap-1 ${badgeClass}`}>
+            <Badge className={`flex items-center gap-1 ${badgeClass}`}>
               <PointIcon className="h-3 w-3" />
               {pointsEarned} pts
             </Badge>
@@ -72,11 +69,11 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
             </div>
 
             <div className="flex items-center gap-2">
-              <div className="w-16 text-center font-bold text-lg">
+              <div className="w-16 text-center font-display font-bold text-lg">
                 {match.home_score}
               </div>
               <span className="text-muted-foreground">:</span>
-              <div className="w-16 text-center font-bold text-lg">
+              <div className="w-16 text-center font-display font-bold text-lg">
                 {match.away_score}
               </div>
             </div>
@@ -98,11 +95,11 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
             </div>
 
             <div className="flex items-center gap-2">
-              <div className="w-16 text-center text-sm border rounded px-2 py-1 bg-muted/50">
+              <div className="w-16 text-center text-sm border rounded px-2 py-1 bg-surface-sunken">
                 {prediction.predicted_home_score}
               </div>
               <span className="text-muted-foreground text-sm">:</span>
-              <div className="w-16 text-center text-sm border rounded px-2 py-1 bg-muted/50">
+              <div className="w-16 text-center text-sm border rounded px-2 py-1 bg-surface-sunken">
                 {prediction.predicted_away_score}
               </div>
             </div>
@@ -123,7 +120,12 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
         {/* Points explanation */}
         {pointsEarned > 0 && (
           <div className="text-center text-xs text-muted-foreground pt-2 border-t">
-            {pointsEarned === 3 * multiplier && t("exactMatch")}
+            {pointsEarned === 3 * multiplier && (
+              <span className="flex items-center justify-center gap-1">
+                <Sparkles className="h-3 w-3 text-success" />
+                {t("exactMatch")}
+              </span>
+            )}
             {pointsEarned === 2 * multiplier && t("correctDifference")}
             {pointsEarned === 1 * multiplier && t("correctWinner")}
           </div>

--- a/components/rankings/rankings-table.tsx
+++ b/components/rankings/rankings-table.tsx
@@ -13,6 +13,20 @@ interface RankingsTableProps {
   tournamentId: string;
 }
 
+function getPodiumStyle(rank: number): string {
+  if (rank === 1) return "border-l-4 border-l-gold bg-gradient-to-r from-[hsl(var(--gold)/0.15)] to-transparent";
+  if (rank === 2) return "border-l-4 border-l-silver bg-gradient-to-r from-[hsl(var(--silver)/0.1)] to-transparent";
+  if (rank === 3) return "border-l-4 border-l-bronze bg-gradient-to-r from-[hsl(var(--bronze)/0.1)] to-transparent";
+  return "";
+}
+
+function getRankColor(rank: number): string {
+  if (rank === 1) return "text-gold";
+  if (rank === 2) return "text-silver";
+  if (rank === 3) return "text-bronze";
+  return "text-muted-foreground";
+}
+
 export function RankingsTable({ rankings, currentUserId, tournamentId }: RankingsTableProps) {
   const t = useTranslations('rankings');
   const tCommon = useTranslations('common');
@@ -31,6 +45,14 @@ export function RankingsTable({ rankings, currentUserId, tournamentId }: Ranking
         <CardTitle>{t('title')}</CardTitle>
       </CardHeader>
       <CardContent>
+        {/* Column Headers */}
+        <div className="flex items-center gap-4 px-3 pb-3 mb-2 border-b text-xs uppercase tracking-wider text-muted-foreground font-medium">
+          <div className="w-8 text-center">{tCommon('labels.rank')}</div>
+          <div className="w-10" />
+          <div className="flex-1">{tCommon('labels.name')}</div>
+          <div>{tCommon('labels.points')}</div>
+        </div>
+
         <div className="space-y-2">
           {rankings.map((ranking, index) => {
             const isCurrentUser = ranking.user_id === currentUserId;
@@ -43,22 +65,18 @@ export function RankingsTable({ rankings, currentUserId, tournamentId }: Ranking
               >
                 <div
                   className={`flex items-center gap-4 p-3 rounded-lg transition-colors cursor-pointer ${
+                    index < 5 ? `animate-slide-up stagger-${Math.min(index + 1, 5)}` : ""
+                  } ${getPodiumStyle(displayRank)} ${
                     isCurrentUser
-                      ? "bg-primary/10 border border-primary hover:bg-primary/20"
+                      ? "ring-2 ring-primary/30 bg-primary/10 hover:bg-primary/20"
                       : "hover:bg-muted"
                   }`}
                 >
                   {/* Rank */}
-                  <div className="w-8 text-center font-bold">
-                    {displayRank <= 3 ? (
-                      <span className="text-2xl">
-                        {displayRank === 1 && "🥇"}
-                        {displayRank === 2 && "🥈"}
-                        {displayRank === 3 && "🥉"}
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">{displayRank}</span>
-                    )}
+                  <div className="w-8 text-center">
+                    <span className={`font-display text-2xl font-bold ${getRankColor(displayRank)}`}>
+                      {displayRank}
+                    </span>
                   </div>
 
                   {/* Avatar */}
@@ -80,7 +98,8 @@ export function RankingsTable({ rankings, currentUserId, tournamentId }: Ranking
                   {/* Points */}
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary">
-                      {ranking.total_points} {tCommon('labels.pts')}
+                      <span className="font-display font-bold">{ranking.total_points}</span>
+                      <span className="ml-1">{tCommon('labels.pts')}</span>
                     </Badge>
                     {isCurrentUser && (
                       <Badge variant="outline">{t('you')}</Badge>

--- a/components/tournaments/tournament-card.tsx
+++ b/components/tournaments/tournament-card.tsx
@@ -11,20 +11,22 @@ interface TournamentCardProps {
   tournament: Tournament;
 }
 
-const statusColors = {
-  upcoming: "bg-blue-500",
-  active: "bg-green-500",
-  completed: "bg-gray-500",
+const statusColors: Record<string, string> = {
+  upcoming: "bg-info",
+  active: "bg-success",
+  completed: "bg-muted",
 };
 
 export function TournamentCard({ tournament }: TournamentCardProps) {
   const t = useTranslations('tournaments.status');
   return (
     <Link href={`/${tournament.id}`}>
-      <Card className="hover:shadow-lg transition-shadow cursor-pointer">
+      <Card className="hover:shadow-lg hover:-translate-y-1 transition-all duration-200 cursor-pointer overflow-hidden">
+        {/* Status stripe at top */}
+        <div className={`h-1 ${statusColors[tournament.status] || "bg-muted"}`} />
         <CardHeader>
           <div className="flex justify-between items-start">
-            <CardTitle>{tournament.name}</CardTitle>
+            <CardTitle className="font-display uppercase tracking-tight">{tournament.name}</CardTitle>
             <Badge variant="outline" className="capitalize">
               {t(tournament.status as 'upcoming' | 'active' | 'completed')}
             </Badge>
@@ -37,7 +39,7 @@ export function TournamentCard({ tournament }: TournamentCardProps) {
         <CardContent>
           <div className="flex items-center gap-2">
             <div
-              className={`h-2 w-2 rounded-full ${statusColors[tournament.status]}`}
+              className={`h-2 w-2 rounded-full ${statusColors[tournament.status] || "bg-muted"}`}
             />
             <span className="text-sm text-muted-foreground capitalize">
               {tournament.sport}

--- a/messages/en.json
+++ b/messages/en.json
@@ -237,6 +237,11 @@
     "description": "Predict match scores, compete with friends, and climb the leaderboard",
     "getStarted": "Get Started",
     "login": "Login",
+    "features": {
+      "predict": "Predict Scores",
+      "compete": "Compete with Friends",
+      "leaderboard": "Climb the Leaderboard"
+    },
     "hero": {
       "title": "Quiniela",
       "subtitle": "Tournament prediction platform for various sports events",
@@ -486,7 +491,9 @@
     "form": {
       "submitPrediction": "Submit Prediction",
       "updatePrediction": "Update Prediction",
-      "saving": "Saving..."
+      "saving": "Saving...",
+      "predicted": "Predicted",
+      "locked": "Locked"
     },
     "results": {
       "finalScore": "Final Score",

--- a/messages/es.json
+++ b/messages/es.json
@@ -237,6 +237,11 @@
     "description": "Pronostica resultados de partidos, compite con amigos y escala en la tabla de posiciones",
     "getStarted": "Comenzar",
     "login": "Iniciar Sesión",
+    "features": {
+      "predict": "Pronostica Resultados",
+      "compete": "Compite con Amigos",
+      "leaderboard": "Escala en la Tabla"
+    },
     "hero": {
       "title": "Quiniela",
       "subtitle": "Plataforma de pronósticos de torneos para la Copa del Mundo y más",
@@ -486,7 +491,9 @@
     "form": {
       "submitPrediction": "Enviar Pronóstico",
       "updatePrediction": "Actualizar Pronóstico",
-      "saving": "Guardando..."
+      "saving": "Guardando...",
+      "predicted": "Pronosticado",
+      "locked": "Bloqueado"
     },
     "results": {
       "finalScore": "Resultado Final",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2444,6 +2444,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
       "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.90.1",
         "@supabase/functions-js": "2.90.1",
@@ -2692,6 +2693,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2702,6 +2704,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2760,6 +2763,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3246,6 +3250,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3691,6 +3696,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4377,6 +4383,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4550,6 +4557,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5770,6 +5778,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6583,6 +6592,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6802,6 +6812,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6811,6 +6822,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7710,6 +7722,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7884,6 +7897,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        display: ["var(--font-display)", "sans-serif"],
+        body: ["var(--font-body)", "sans-serif"],
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
@@ -40,6 +44,23 @@ const config: Config = {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        gold: "hsl(var(--gold))",
+        silver: "hsl(var(--silver))",
+        bronze: "hsl(var(--bronze))",
+        "surface-elevated": "hsl(var(--surface-elevated))",
+        "surface-sunken": "hsl(var(--surface-sunken))",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Summary

- **Design system expansion**: Added semantic color tokens (success, warning, info, gold/silver/bronze, surface layers) to CSS variables and Tailwind config, then migrated all hardcoded colors across components to use them
- **Typography upgrade**: Added Oswald as a condensed sports display font for headings, creating a clear visual hierarchy while keeping Inter as the body font
- **Animation system**: Added CSS-only GPU-composited animations (fade-in, slide-up, scale-in, score-pop, pulse-live) with stagger delays for cascading list entrances
- **Landing page redesign**: Dramatic Oswald title, gradient subtitle, feature pills with icons, radial spotlight background, and hover-scale CTAs
- **Login page UX fix**: Eliminated duplicated email field by lifting email state to parent and sharing between passkey and password auth flows
- **Navigation polish**: Frosted glass backdrop-blur sticky nav bar, active-state link indicators, admin links grouped with Shield icon, mobile nav with icons and smoother transitions
- **Component upgrades**: Podium-colored leaderboard rows (gold/silver/bronze), live match glow + pulse, score-pop animations, hover lift effects, larger prediction inputs, predicted/locked status badges, Sparkles icon for exact scores
- **i18n**: Added new keys for landing page features and prediction form states in both English and Spanish

## Test plan

- [ ] Run `npm run build` -- verify zero TypeScript/build errors
- [ ] Check landing page on desktop and mobile (375px) -- Oswald title, feature pills, gradient subtitle, spotlight background
- [ ] Check login page -- single shared email field works for both passkey and password flows
- [ ] Check signup page -- spotlight background, scale-in animation
- [ ] Toggle dark mode -- verify all new semantic colors have proper dark-mode equivalents
- [ ] Switch language to Spanish -- verify new i18n keys display correctly
- [ ] Check tournament dashboard -- large Oswald title, podium colors on leaderboard, bold stat numbers
- [ ] Check match cards -- live match glow, score-pop animation, Zap multiplier icon, hover lift
- [ ] Check rankings table -- gradient podium rows, colored rank numbers, column headers
- [ ] Check prediction form -- larger score inputs, predicted/locked badges, round badge in header
- [ ] Verify no hardcoded color classes (bg-green-500, bg-blue-500, etc.) remain in modified components

🤖 Generated with [Claude Code](https://claude.com/claude-code)