### PR TITLE
feat: add user account deactivation with soft delete

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { AppNav } from "@/components/layout/app-nav";
+import { redirect } from "next/navigation";
 
 export default async function AppLayout({
   children,
@@ -32,6 +33,12 @@ export default async function AppLayout({
       userProfile = newProfile;
     } else {
       userProfile = data;
+    }
+
+    // Check if user is deactivated and sign them out
+    if (userProfile?.status === 'deactivated') {
+      await supabase.auth.signOut();
+      redirect('/login?error=account_deactivated');
     }
   }
 

--- a/app/api/account/deactivate/route.ts
+++ b/app/api/account/deactivate/route.ts
@@ -1,0 +1,53 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { getCurrentUTC } from "@/lib/utils/date";
+
+/**
+ * POST /api/account/deactivate
+ * User self-service account deactivation
+ *
+ * Effects:
+ * - Sets user status to 'deactivated'
+ * - Signs out the user immediately
+ * - Prevents login and prediction submission
+ * - Removes user from rankings
+ * - Preserves all historical data
+ */
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // Update status to deactivated
+    const { error } = await supabase
+      .from("users")
+      .update({
+        status: "deactivated",
+        updated_at: getCurrentUTC(),
+      })
+      .eq("id", user.id);
+
+    if (error) throw error;
+
+    // Sign out the user
+    await supabase.auth.signOut();
+
+    return NextResponse.json({
+      success: true,
+      message: "Account deactivated successfully"
+    });
+  } catch (error) {
+    console.error("Error deactivating account:", error);
+    return NextResponse.json(
+      { error: "Failed to deactivate account" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/users/[userId]/status/route.ts
+++ b/app/api/admin/users/[userId]/status/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
+import { updateUserStatus } from "@/lib/utils/admin";
+
+/**
+ * PATCH /api/admin/users/[userId]/status
+ * Admin-only user status management
+ *
+ * Request body:
+ * {
+ *   "status": "active" | "deactivated"
+ * }
+ *
+ * Effects of deactivation:
+ * - User cannot log in
+ * - User cannot submit predictions
+ * - User is removed from rankings
+ * - All historical data is preserved
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
+  try {
+    const { userId } = await params;
+    const body = await request.json();
+    const { status } = body;
+
+    if (!['active', 'deactivated'].includes(status)) {
+      return NextResponse.json(
+        { error: "Invalid status. Must be 'active' or 'deactivated'." },
+        { status: 400 }
+      );
+    }
+
+    await updateUserStatus(userId, status);
+
+    return NextResponse.json({ success: true, status });
+  } catch (error) {
+    console.error("Error updating user status:", error);
+    return NextResponse.json(
+      { error: "Failed to update user status" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/predictions/route.ts
+++ b/app/api/predictions/route.ts
@@ -1,9 +1,14 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUTC } from "@/lib/utils/date";
+import { checkUserActive } from "@/lib/middleware/user-status-check";
 
 export async function POST(request: NextRequest) {
   try {
+    // Check user is active
+    const statusError = await checkUserActive();
+    if (statusError) return statusError;
+
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
 

--- a/components/profile/account-deactivation-dialog.tsx
+++ b/components/profile/account-deactivation-dialog.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Loader2, UserX } from "lucide-react";
+import { useFeatureToast } from "@/lib/hooks/use-feature-toast";
+
+export function AccountDeactivationDialog() {
+  const router = useRouter();
+  const t = useTranslations("profile.deactivation");
+  const tCommon = useTranslations("common");
+  const toast = useFeatureToast('profile');
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDeactivate = async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/account/deactivate", {
+        method: "POST",
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to deactivate account");
+      }
+
+      toast.success("success.accountDeactivated");
+      setIsOpen(false);
+
+      // Redirect to home page after a short delay
+      setTimeout(() => {
+        router.push("/");
+      }, 1000);
+    } catch (err) {
+      console.error(err);
+      toast.error("error.failedToDeactivate");
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">
+          <UserX className="mr-2 h-4 w-4" />
+          {t("buttonText")}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("title")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("description")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-4 space-y-3">
+            <p className="font-medium text-destructive">{t("consequences.title")}</p>
+            <ul className="list-disc list-inside text-sm space-y-1 text-muted-foreground">
+              <li>{t("consequences.hiddenProfile")}</li>
+              <li>{t("consequences.noLeaderboards")}</li>
+              <li>{t("consequences.cannotLogin")}</li>
+              <li>{t("consequences.dataPreserved")}</li>
+            </ul>
+          </div>
+
+          <div className="bg-muted/50 rounded-md p-3 text-sm">
+            <p className="text-muted-foreground">{t("reactivationNote")}</p>
+          </div>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>{tCommon("cancel")}</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            onClick={handleDeactivate}
+            disabled={isLoading}
+          >
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isLoading ? t("deactivating") : t("confirm")}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/profile/profile-editor.tsx
+++ b/components/profile/profile-editor.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { formatLocalDate, formatLocalTime } from "@/lib/utils/date";
+import { AccountDeactivationDialog } from "@/components/profile/account-deactivation-dialog";
 
 interface ProfileEditorProps {
   user: User;
@@ -168,6 +169,19 @@ export function ProfileEditor({ user, onUpdate }: ProfileEditorProps) {
               </code>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Danger Zone Card */}
+      <Card className="border-destructive">
+        <CardHeader>
+          <CardTitle className="text-destructive">{t('dangerZone.title')}</CardTitle>
+          <CardDescription>
+            {t('dangerZone.subtitle')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AccountDeactivationDialog />
         </CardContent>
       </Card>
     </div>

--- a/lib/middleware/user-status-check.ts
+++ b/lib/middleware/user-status-check.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Check if authenticated user is deactivated
+ * Returns error response if deactivated, null if active
+ *
+ * Usage in API routes:
+ * ```typescript
+ * const statusError = await checkUserActive();
+ * if (statusError) return statusError;
+ * ```
+ */
+export async function checkUserActive(): Promise<NextResponse | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: userProfile } = await supabase
+    .from("users")
+    .select("status")
+    .eq("id", user.id)
+    .single();
+
+  if (userProfile?.status === 'deactivated') {
+    await supabase.auth.signOut();
+
+    return NextResponse.json(
+      { error: "Account deactivated. Please contact an administrator." },
+      { status: 403 }
+    );
+  }
+
+  return null;
+}

--- a/lib/utils/admin.ts
+++ b/lib/utils/admin.ts
@@ -65,3 +65,32 @@ export async function updateUserAdminStatus(
 
   if (error) throw error;
 }
+
+/**
+ * Updates user account status (active/deactivated)
+ *
+ * Deactivated users:
+ * - Cannot log in
+ * - Cannot submit predictions
+ * - Are excluded from rankings
+ * - Preserve all historical data
+ *
+ * @param userId - User ID to update
+ * @param status - New status ('active' or 'deactivated')
+ */
+export async function updateUserStatus(
+  userId: string,
+  status: 'active' | 'deactivated'
+): Promise<void> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient
+    .from("users")
+    .update({
+      status,
+      updated_at: new Date().toISOString()
+    })
+    .eq("id", userId);
+
+  if (error) throw error;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -532,11 +532,32 @@
     "subtitle": "Manage your account settings and preferences",
     "messages": {
       "success": {
-        "profileUpdated": "Profile updated successfully"
+        "profileUpdated": "Profile updated successfully",
+        "accountDeactivated": "Account deactivated successfully"
       },
       "error": {
-        "failedToUpdate": "Failed to update profile"
+        "failedToUpdate": "Failed to update profile",
+        "failedToDeactivate": "Failed to deactivate account"
       }
+    },
+    "dangerZone": {
+      "title": "Danger Zone",
+      "subtitle": "Irreversible account actions"
+    },
+    "deactivation": {
+      "buttonText": "Deactivate Account",
+      "title": "Deactivate Your Account?",
+      "description": "This will immediately deactivate your account and sign you out.",
+      "consequences": {
+        "title": "What happens when you deactivate:",
+        "hiddenProfile": "Your profile will be hidden from other users",
+        "noLeaderboards": "You won't appear on leaderboards or rankings",
+        "cannotLogin": "You won't be able to log in or make predictions",
+        "dataPreserved": "Your predictions and data will be preserved"
+      },
+      "reactivationNote": "To reactivate your account, contact an administrator.",
+      "deactivating": "Deactivating...",
+      "confirm": "Yes, Deactivate My Account"
     },
     "edit": {
       "title": "Edit Profile",
@@ -568,10 +589,13 @@
     "messages": {
       "success": {
         "adminGranted": "Admin permissions granted to {name}",
-        "adminRevoked": "Admin permissions revoked from {name}"
+        "adminRevoked": "Admin permissions revoked from {name}",
+        "userDeactivated": "User {name} deactivated successfully",
+        "userActivated": "User {name} activated successfully"
       },
       "error": {
-        "failedToUpdatePermissions": "Failed to update permissions"
+        "failedToUpdatePermissions": "Failed to update permissions",
+        "failedToUpdateStatus": "Failed to update user status"
       }
     },
     "users": {
@@ -579,6 +603,11 @@
       "subtitle": "Manage users and grant admin permissions",
       "admin": "Admin",
       "user": "User",
+      "active": "Active",
+      "deactivated": "Deactivated",
+      "all": "All Users",
+      "activate": "Activate User",
+      "deactivate": "Deactivate User",
       "tournaments": "Tournaments",
       "predictions": "Predictions",
       "totalPoints": "Total Points",

--- a/messages/es.json
+++ b/messages/es.json
@@ -532,11 +532,32 @@
     "subtitle": "Administra la configuración y preferencias de tu cuenta",
     "messages": {
       "success": {
-        "profileUpdated": "Perfil actualizado exitosamente"
+        "profileUpdated": "Perfil actualizado exitosamente",
+        "accountDeactivated": "Cuenta desactivada exitosamente"
       },
       "error": {
-        "failedToUpdate": "Error al actualizar perfil"
+        "failedToUpdate": "Error al actualizar perfil",
+        "failedToDeactivate": "Error al desactivar cuenta"
       }
+    },
+    "dangerZone": {
+      "title": "Zona de Peligro",
+      "subtitle": "Acciones irreversibles de la cuenta"
+    },
+    "deactivation": {
+      "buttonText": "Desactivar Cuenta",
+      "title": "¿Desactivar Tu Cuenta?",
+      "description": "Esto desactivará inmediatamente tu cuenta y cerrará tu sesión.",
+      "consequences": {
+        "title": "Qué sucede cuando desactivas:",
+        "hiddenProfile": "Tu perfil estará oculto para otros usuarios",
+        "noLeaderboards": "No aparecerás en las tablas de clasificación",
+        "cannotLogin": "No podrás iniciar sesión ni hacer pronósticos",
+        "dataPreserved": "Tus pronósticos y datos se conservarán"
+      },
+      "reactivationNote": "Para reactivar tu cuenta, contacta a un administrador.",
+      "deactivating": "Desactivando...",
+      "confirm": "Sí, Desactivar Mi Cuenta"
     },
     "edit": {
       "title": "Editar Perfil",
@@ -568,10 +589,13 @@
     "messages": {
       "success": {
         "adminGranted": "Permisos de administrador otorgados a {name}",
-        "adminRevoked": "Permisos de administrador revocados de {name}"
+        "adminRevoked": "Permisos de administrador revocados de {name}",
+        "userDeactivated": "Usuario {name} desactivado exitosamente",
+        "userActivated": "Usuario {name} activado exitosamente"
       },
       "error": {
-        "failedToUpdatePermissions": "Error al actualizar permisos"
+        "failedToUpdatePermissions": "Error al actualizar permisos",
+        "failedToUpdateStatus": "Error al actualizar estado del usuario"
       }
     },
     "users": {
@@ -579,6 +603,11 @@
       "subtitle": "Administra usuarios y otorga permisos de administrador",
       "admin": "Admin",
       "user": "Usuario",
+      "active": "Activo",
+      "deactivated": "Desactivado",
+      "all": "Todos los Usuarios",
+      "activate": "Activar Usuario",
+      "deactivate": "Desactivar Usuario",
       "tournaments": "Torneos",
       "predictions": "pronósticos",
       "totalPoints": "Puntos Totales",

--- a/supabase/migrations/20260215000000_add_user_status.sql
+++ b/supabase/migrations/20260215000000_add_user_status.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- Add User Status Column for Soft Delete
+-- ============================================================================
+-- Migration: 20260215000000_add_user_status
+-- Created: 2026-02-15
+-- Description: Adds status column to users table to support account deactivation
+--              and updates tournament_rankings view to exclude deactivated users.
+--              Also updates RLS policies to block deactivated users from predictions.
+-- ============================================================================
+
+-- Add status column to users table
+ALTER TABLE public.users
+ADD COLUMN status TEXT DEFAULT 'active'
+CHECK (status IN ('active', 'deactivated'));
+
+-- Set all existing users to active
+UPDATE public.users SET status = 'active' WHERE status IS NULL;
+
+-- Add partial index for performance (only indexes deactivated users)
+CREATE INDEX idx_users_status ON public.users(status)
+WHERE status = 'deactivated';
+
+-- Update tournament_rankings VIEW to exclude deactivated users
+CREATE OR REPLACE VIEW public.tournament_rankings
+WITH (security_invoker = true) AS
+SELECT
+    p.user_id,
+    m.tournament_id,
+    u.screen_name,
+    u.avatar_url,
+    COUNT(DISTINCT p.id) AS predictions_count,
+    COALESCE(SUM(p.points_earned), 0) AS total_points,
+    RANK() OVER (
+        PARTITION BY m.tournament_id
+        ORDER BY COALESCE(SUM(p.points_earned), 0) DESC
+    ) AS rank
+FROM public.predictions p
+JOIN public.matches m ON p.match_id = m.id
+JOIN public.users u ON p.user_id = u.id
+JOIN public.tournament_participants tp
+    ON tp.tournament_id = m.tournament_id
+    AND tp.user_id = p.user_id
+WHERE u.status = 'active'  -- NEW: Filter deactivated users
+GROUP BY p.user_id, m.tournament_id, u.screen_name, u.avatar_url;
+
+-- Update RLS policies to block deactivated users from inserting predictions
+DROP POLICY IF EXISTS "Users can insert their own predictions" ON public.predictions;
+CREATE POLICY "Users can insert their own predictions"
+    ON public.predictions FOR INSERT
+    WITH CHECK (
+        auth.uid() = user_id
+        AND EXISTS (
+            SELECT 1 FROM public.users
+            WHERE id = auth.uid() AND status = 'active'
+        )
+    );
+
+-- Update RLS policies to block deactivated users from updating predictions
+DROP POLICY IF EXISTS "Users can update own predictions" ON public.predictions;
+DROP POLICY IF EXISTS "Users can update their own predictions" ON public.predictions;
+CREATE POLICY "Users can update their own predictions"
+    ON public.predictions FOR UPDATE
+    USING (
+        auth.uid() = user_id OR public.is_admin(auth.uid())
+    )
+    WITH CHECK (
+        (auth.uid() = user_id AND EXISTS (
+            SELECT 1 FROM public.users
+            WHERE id = auth.uid() AND status = 'active'
+        ))
+        OR public.is_admin(auth.uid())
+    );
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/types/database.ts
+++ b/types/database.ts
@@ -8,6 +8,7 @@ export type Json =
 
 export type MatchStatus = 'scheduled' | 'in_progress' | 'completed' | 'cancelled'
 export type TournamentStatus = 'upcoming' | 'active' | 'completed'
+export type UserStatus = 'active' | 'deactivated'
 
 export interface Team {
   id: string
@@ -64,6 +65,7 @@ export interface User {
   screen_name: string | null
   avatar_url: string | null
   is_admin: boolean
+  status: UserStatus
   last_login: string | null
   created_at: string
   updated_at: string


### PR DESCRIPTION
Implement soft delete functionality allowing users to deactivate their own accounts and admins to manage user status. Deactivated users are excluded from rankings and cannot submit predictions, while preserving all historical data for tournament integrity.

Key changes:
- Database: Add status column to users table with RLS policy enforcement
- Admin UI: Status filtering and activate/deactivate controls
- User UI: Self-service deactivation from profile settings
- API: Account deactivation and admin status management endpoints
- Security: Multi-level blocking (layout, RLS, API) for deactivated users
- i18n: Full English and Spanish translations

Addresses tournament organizers' need to manage user participation without corrupting historical prediction data or breaking referential integrity.