### PR TITLE
feat: add Husky git hooks with lint-staged and Prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Run lint-staged (formats and lints only staged files)
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Type check and build before pushing
+npm run type-check
+npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,21 @@
+# Build outputs
+.next
+out
+build
+dist
+
+# Dependencies
+node_modules
+
+# Config files
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Generated files
+*.tsbuildinfo
+next-env.d.ts
+
+# Supabase migrations (don't auto-format SQL)
+supabase/migrations/**/*.sql
+supabase/bootstrap.sql

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "endOfLine": "auto"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Quiniela is a multi-tournament prediction application initially designed for the
 - [Scoring Logic](#scoring-logic)
 - [API Routes](#api-routes)
 - [Best Practices & Conventions](#best-practices--conventions)
+- [Git Hooks & Code Quality Automation](#git-hooks--code-quality-automation)
 - [Common Gotchas](#common-gotchas)
 - [Troubleshooting](#troubleshooting)
 - [Adding New Tournaments](#adding-new-tournaments)
@@ -40,11 +41,16 @@ Quiniela is a multi-tournament prediction application initially designed for the
 import { useFeatureToast } from "@/lib/hooks/use-feature-toast";
 
 // Supabase clients
-import { createClient } from "@/lib/supabase/server";  // Server Components
-import { createClient } from "@/lib/supabase/client";  // Client Components
+import { createClient } from "@/lib/supabase/server"; // Server Components
+import { createClient } from "@/lib/supabase/client"; // Client Components
 
 // Date utilities
-import { formatLocalDate, formatLocalDateTime, formatLocalTime, isPastDate } from "@/lib/utils/date";
+import {
+  formatLocalDate,
+  formatLocalDateTime,
+  formatLocalTime,
+  isPastDate,
+} from "@/lib/utils/date";
 
 // Image uploads
 import { uploadImage, generateImageFilename } from "@/lib/utils/image";
@@ -81,19 +87,26 @@ formatLocalDateTime(match.date_time)  // "Jun 11, 2026 at 12:00"
 // Image upload
 const filename = generateImageFilename(teamId, file);
 const url = await uploadImage(file, "team-logos", filename);
+
+// Code formatting
+npm run format                    // Format all files
+npm run format:check              // Check formatting
 ```
 
 ## Tech Stack
 
 **Core:**
+
 - Next.js 15+ (App Router) + React 19 + TypeScript
 - Tailwind CSS + shadcn/ui components
 
 **Backend:**
+
 - Supabase (PostgreSQL + Auth + Storage + RLS)
 - Next.js API routes (serverless functions)
 
 **Key Libraries & Patterns:**
+
 - Date handling: Native JS (UTC storage, local timezone display)
 - Toast notifications: Custom hook with i18n support
 - Image optimization: Next.js Image component
@@ -102,15 +115,18 @@ const url = await uploadImage(file, "team-logos", filename);
 ## Requirements & Compatibility
 
 **Development Requirements:**
+
 - Node.js 20.x or higher
 - npm 10.x or higher
 - Supabase project (free tier works fine)
 
 **Environment Setup:**
+
 - `.env.local` with Supabase credentials (see `.env.example`)
 - Supabase storage buckets configured (team-logos, user-avatars)
 
 **Browser Support:**
+
 - Modern browsers (Chrome, Firefox, Safari, Edge latest versions)
 - Mobile browsers (iOS Safari 14+, Chrome Android)
 
@@ -138,12 +154,14 @@ npm run lint
 ### When to Use Server vs Client Components
 
 **Server Component (default):**
+
 - Data fetching from database
 - Static content rendering
 - No user interaction needed
 - SEO-critical pages
 
 **Client Component ("use client"):**
+
 - Forms with state management
 - onClick handlers, useState, useEffect hooks
 - Toast notifications
@@ -189,15 +207,15 @@ Use `useFeatureToast(namespace)` for all user feedback with automatic localizati
 ```typescript
 import { useFeatureToast } from "@/lib/hooks/use-feature-toast";
 
-const toast = useFeatureToast('teams');
-toast.success('success.created');           // Feature-specific
-toast.error('common:error.generic');        // Common message
+const toast = useFeatureToast("teams");
+toast.success("success.created"); // Feature-specific
+toast.error("common:error.generic"); // Common message
 toast.promise(asyncOp, { loading, success, error }); // Loading states
 ```
 
 ### Key Features
 
-- Feature-scoped localization (teams.messages.*, matches.messages.*, etc.)
+- Feature-scoped localization (teams.messages._, matches.messages._, etc.)
 - Automatic fallback to common messages
 - Promise pattern for loading states (status:creating → success/error)
 - Rich colors (green/red/yellow/blue backgrounds)
@@ -205,6 +223,7 @@ toast.promise(asyncOp, { loading, success, error }); // Loading states
 ### Message Organization
 
 **Feature-Specific** (use without prefix):
+
 - `teams.messages.*` - Team operations
 - `matches.messages.*` - Match operations and scoring
 - `tournaments.messages.*` - Tournament operations
@@ -213,6 +232,7 @@ toast.promise(asyncOp, { loading, success, error }); // Loading states
 - `profile.messages.*` - Profile updates
 
 **Common** (use with `common:` prefix):
+
 - `common.messages.success.*` - Generic success (saved, created, updated, deleted)
 - `common.messages.error.*` - Generic errors (generic, networkError, unauthorized)
 - `common.status.*` - Loading states (saving, creating, updating, deleting)
@@ -220,6 +240,7 @@ toast.promise(asyncOp, { loading, success, error }); // Loading states
 ### Full Documentation
 
 📖 See **[TOASTS.md](./TOASTS.md)** for:
+
 - Complete API reference
 - Promise pattern examples
 - Best practices and guidelines
@@ -233,20 +254,27 @@ All dates are stored in **UTC** in the database (PostgreSQL `TIMESTAMPTZ` type) 
 ### Date Utilities
 
 ```typescript
-import { formatLocalDate, formatLocalDateTime, formatLocalTime, isPastDate, isFutureDate, getCurrentUTC } from "@/lib/utils/date";
+import {
+  formatLocalDate,
+  formatLocalDateTime,
+  formatLocalTime,
+  isPastDate,
+  isFutureDate,
+  getCurrentUTC,
+} from "@/lib/utils/date";
 
 // Display dates (automatic timezone conversion)
-formatLocalDate("2026-06-11T16:00:00Z")        // "Jun 11, 2026"
-formatLocalDateTime("2026-06-11T16:00:00Z")    // "Jun 11, 2026 at 12:00"
-formatLocalTime("2026-06-11T16:00:00Z")        // "12:00"
+formatLocalDate("2026-06-11T16:00:00Z"); // "Jun 11, 2026"
+formatLocalDateTime("2026-06-11T16:00:00Z"); // "Jun 11, 2026 at 12:00"
+formatLocalTime("2026-06-11T16:00:00Z"); // "12:00"
 
 // Check date status
-isPastDate("2026-06-11T16:00:00Z")             // true/false
-isFutureDate("2026-06-11T16:00:00Z")           // true/false
+isPastDate("2026-06-11T16:00:00Z"); // true/false
+isFutureDate("2026-06-11T16:00:00Z"); // true/false
 
 // Store dates (always use UTC)
-getCurrentUTC()                                 // "2026-01-17T20:30:45.123Z"
-new Date().toISOString()                       // "2026-01-17T20:30:45.123Z"
+getCurrentUTC(); // "2026-01-17T20:30:45.123Z"
+new Date().toISOString(); // "2026-01-17T20:30:45.123Z"
 ```
 
 ### Rules
@@ -262,33 +290,37 @@ new Date().toISOString()                       // "2026-01-17T20:30:45.123Z"
 
 Required in `.env.local` (see `.env.example`):
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `NEXT_PUBLIC_SUPABASE_URL` | Yes | Your Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Supabase anonymous key (public) |
-| `SUPABASE_SERVICE_ROLE_KEY` | Optional | For admin operations (keep secret) |
+| Variable                        | Required | Description                        |
+| ------------------------------- | -------- | ---------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Yes      | Your Supabase project URL          |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes      | Supabase anonymous key (public)    |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Optional | For admin operations (keep secret) |
 
 ### Client Usage Patterns
 
 **Server Components**:
+
 ```typescript
 import { createClient } from "@/lib/supabase/server";
-const supabase = await createClient();  // Note: await is required
+const supabase = await createClient(); // Note: await is required
 ```
 
 **Client Components**:
+
 ```typescript
 import { createClient } from "@/lib/supabase/client";
-const supabase = createClient();  // No await needed
+const supabase = createClient(); // No await needed
 ```
 
 **Middleware** (for auth refresh):
+
 - Uses `lib/supabase/middleware.ts`
 - Configured in `middleware.ts` at root
 
 ### Row Level Security (RLS)
 
 All tables have RLS enabled:
+
 - **Public read**: teams, tournaments, matches, tournament_teams, users, predictions, rankings
 - **Authenticated write**: users can only update their own profile and predictions
 - **Admin operations**: Match scoring requires elevated permissions (implement admin checks)
@@ -404,6 +436,7 @@ Users can be in one of two states: `active` or `deactivated`.
 ### User Self-Deactivation
 
 Users can deactivate their own accounts from profile settings:
+
 - Immediate status change to 'deactivated'
 - Automatic logout
 - All predictions and data preserved
@@ -412,14 +445,16 @@ Users can deactivate their own accounts from profile settings:
 ### Admin User Management
 
 Admins can activate/deactivate any user:
+
 ```typescript
 import { updateUserStatus } from "@/lib/utils/admin";
-await updateUserStatus(userId, 'deactivated');
+await updateUserStatus(userId, "deactivated");
 ```
 
 ### Effects of Deactivation
 
 When a user is deactivated:
+
 - Cannot log in (blocked at app layout level)
 - Cannot submit or update predictions (RLS policy blocks)
 - Excluded from tournament rankings (VIEW filter: `WHERE u.status = 'active'`)
@@ -429,6 +464,7 @@ When a user is deactivated:
 ### Checking User Status
 
 In API routes:
+
 ```typescript
 import { checkUserActive } from "@/lib/middleware/user-status-check";
 
@@ -437,8 +473,9 @@ if (statusError) return statusError;
 ```
 
 In components (user is already loaded):
+
 ```typescript
-if (user.status === 'deactivated') {
+if (user.status === "deactivated") {
   // Handle deactivated user
 }
 ```
@@ -450,6 +487,7 @@ The application uses a flexible CSS variable-based theming system powered by the
 ### Current Palette
 
 **Blue Lagoon** from [Coolors.co](https://coolors.co/palette/00a6fb-0582ca-006494-003554-051923):
+
 - `#00A6FB` - Vivid Cerulean (accents, highlights)
 - `#0582CA` - Honolulu Blue (primary brand color)
 - `#006494` - Sea Blue (muted elements)
@@ -461,6 +499,7 @@ The application uses a flexible CSS variable-based theming system powered by the
 All theme colors are defined in **one place**: `app/globals.css`
 
 To update the entire color scheme:
+
 1. Edit the CSS variables in the `:root` section (light mode)
 2. Edit the CSS variables in the `.dark` section (dark mode)
 3. Save - the entire app updates automatically!
@@ -491,6 +530,7 @@ The final score is multiplied by the match's `multiplier` value (default: 1).
 ### Match Scoring Process
 
 When a match is scored (via `/api/matches/[matchId]/score`):
+
 1. Match status updates to the provided status (e.g., "completed")
 2. If status is "completed": All predictions for that match are scored
 3. If status changes FROM "completed" TO another status: All prediction scores are reset to 0
@@ -499,15 +539,18 @@ When a match is scored (via `/api/matches/[matchId]/score`):
 ## API Routes
 
 ### User Management
+
 - `POST /api/account/deactivate` - User self-deactivation (signs out user immediately)
 - `PATCH /api/admin/users/[userId]/status` - Admin activate/deactivate user
 - `GET /api/admin/users` - Get all users with stats (includes status)
 - `PATCH /api/admin/users/[userId]/permissions` - Toggle admin permissions
 
 ### Match Operations
+
 - `POST /api/matches/[matchId]/score` - Score match and calculate prediction points
 
 ### Predictions
+
 - `POST /api/predictions` - Submit or update prediction (checks user is active)
 
 ## Best Practices & Conventions
@@ -554,6 +597,105 @@ When a match is scored (via `/api/matches/[matchId]/score`):
 - **Transactions** - use database transactions for multi-step operations
 - **Query optimization** - use indexes for frequently queried columns
 
+## Git Hooks & Code Quality Automation
+
+This project uses Husky with lint-staged and Prettier to enforce code quality automatically.
+
+### Pre-commit Checks (runs on every commit)
+
+**Automated via lint-staged:**
+
+- Prettier formatting (auto-formats all staged files)
+- ESLint validation (auto-fixes when possible)
+
+**What gets formatted:**
+
+- TypeScript/JavaScript files (`.ts`, `.tsx`, `.js`, `.jsx`)
+- JSON, CSS, Markdown files
+
+**Performance:** ~2-4 seconds per commit (only checks staged files)
+
+### Pre-push Checks (runs before pushing to remote)
+
+- TypeScript type checking (`tsc --noEmit`)
+- Full production build (`npm run build`)
+
+**Performance:** ~20-30 seconds per push
+
+### Manual Commands
+
+```bash
+# Format entire project
+npm run format
+
+# Check if files are formatted (no changes)
+npm run format:check
+
+# Fix all ESLint errors
+npm run lint:fix
+
+# Type check without building
+npm run type-check
+```
+
+### Prettier Configuration
+
+Located in `.prettierrc`:
+
+- 2-space indentation
+- Semicolons required
+- Double quotes for consistency with JSX
+- 100-character line width
+- Auto line endings (handles Windows/Unix)
+
+### Bypassing Hooks (Emergency Only)
+
+**When to use:** Critical hotfixes, WIP commits that need to be saved urgently
+
+```bash
+# Skip pre-commit hooks
+git commit --no-verify -m "emergency: bypass hooks"
+
+# Skip pre-push hooks
+git push --no-verify
+```
+
+**Important:** Use sparingly! Bypassed commits can break CI/CD or introduce linting errors.
+
+### Troubleshooting
+
+**Hooks not running:**
+
+```bash
+# Verify git hooks path
+git config core.hooksPath  # Should output: .husky/_
+
+# Reinstall hooks
+npx husky install
+```
+
+**Formatting conflicts:**
+
+```bash
+# Format your local files
+npm run format
+
+# Check what's different
+git diff
+```
+
+**Slow commits (rare):**
+
+- Check how many files are staged: `git diff --cached --name-only`
+- If formatting many files at once, consider committing in smaller batches
+- Typical commit times: 2-4 seconds
+
+**Pre-push taking too long:**
+
+- Type checking and builds are comprehensive (20-30s is normal)
+- Consider if you can break commits into smaller logical units
+- Use `--no-verify` only for urgent hotfixes
+
 ## Common Gotchas
 
 Things that will definitely bite you if you're not careful:
@@ -577,39 +719,47 @@ Things that will definitely bite you if you're not careful:
 ## Troubleshooting
 
 ### "Supabase client not initialized"
+
 → Check `.env.local` has `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`  
 → Verify environment variables are loaded (restart dev server after changes)
 
 ### Toast messages showing translation keys instead of text
+
 → Check namespace matches feature area (e.g., `useFeatureToast('teams')` for team operations)  
 → Verify translation keys exist in `/messages/[locale]/[feature].json`  
 → For common messages, ensure you're using the `common:` prefix
 
 ### Dates showing in UTC instead of local time
+
 → Use `formatLocalDateTime()`, `formatLocalDate()`, or `formatLocalTime()` - NOT `.toLocaleString()`  
 → Verify date is stored as ISO string in database
 
 ### Rankings not updating after scoring a match
+
 → Rankings should update automatically via database view - check that `tournament_rankings` view exists  
 → Run query manually to verify: `SELECT * FROM tournament_rankings WHERE tournament_id = '...'`  
 → Check RLS policies allow reading from the view
 
 ### Images not uploading to Supabase Storage
+
 → Verify storage buckets exist and are public (team-logos, user-avatars)  
 → Check bucket policies allow INSERT for authenticated users  
 → Verify file size is under bucket limits (default 50MB)
 
 ### "Module not found" errors in production build
+
 → Check imports use aliases correctly (`@/lib/...` not `../../../lib/...`)  
 → Verify `tsconfig.json` has correct path mappings  
 → Clear `.next` folder and rebuild
 
 ### Middleware not refreshing auth tokens
+
 → Ensure `middleware.ts` is at project root (not in `/app`)  
 → Check matcher config includes protected routes  
 → Verify Supabase middleware helper is imported correctly
 
 ### Client component errors about "use server"
+
 → You're likely importing a server action in a client component  
 → Move server actions to separate files and import them properly  
 → Check that API routes are being called via fetch, not direct imports
@@ -621,6 +771,7 @@ The file `supabase/bootstrap.sql` contains the complete database schema and must
 ### When to Update
 
 Update `supabase/bootstrap.sql` after ANY of these changes:
+
 - Adding, modifying, or removing tables
 - Adding, modifying, or removing columns
 - Adding, modifying, or removing indexes

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "autoprefixer": "^10.4.19",
         "eslint": "^9",
         "eslint-config-next": "^15.1.5",
+        "lint-staged": "^16.2.7",
         "postcss": "^8.4.39",
+        "prettier": "^3.8.1",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5"
@@ -2444,7 +2446,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
       "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.90.1",
         "@supabase/functions-js": "2.90.1",
@@ -2693,7 +2694,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2704,7 +2704,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2763,7 +2762,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3250,7 +3248,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3283,6 +3280,35 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -3696,7 +3722,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3868,6 +3893,39 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3900,6 +3958,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4177,6 +4242,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
@@ -4383,7 +4461,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4557,7 +4634,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4804,6 +4880,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5023,6 +5106,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5510,6 +5606,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -5778,7 +5890,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5917,6 +6028,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5939,6 +6103,26 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5996,6 +6180,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6036,6 +6233,19 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -6409,6 +6619,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6536,6 +6762,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -6592,7 +6831,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6746,6 +6984,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6812,7 +7066,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6822,7 +7075,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7020,6 +7272,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7030,6 +7299,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7322,6 +7598,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7360,6 +7679,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -7473,6 +7819,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -7722,7 +8084,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7897,7 +8258,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8186,6 +8546,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -8205,6 +8621,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,20 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix",
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "type-check": "tsc --noEmit"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{json,css,md}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -37,7 +50,9 @@
     "autoprefixer": "^10.4.19",
     "eslint": "^9",
     "eslint-config-next": "^15.1.5",
+    "lint-staged": "^16.2.7",
     "postcss": "^8.4.39",
+    "prettier": "^3.8.1",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5"


### PR DESCRIPTION
Implement automated code quality enforcement at commit and push time:

**Pre-commit hooks (via lint-staged):**
- Auto-format all staged files with Prettier (2-space indent, semicolons, double quotes)
- Auto-fix ESLint errors when possible
- Only checks staged files for fast commits (~2-4 seconds)

**Pre-push hooks:**
- TypeScript type checking (tsc --noEmit)
- Full production build validation
- Comprehensive checks before code reaches remote (~20-30 seconds)

**Configuration added:**
- .prettierrc: Formatting rules (100-char line width, auto line endings for cross-platform)
- .prettierignore: Exclude build outputs, dependencies, and SQL migrations
- .husky/pre-commit: Runs lint-staged on staged files only
- .husky/pre-push: Validates types and build before push
- .vscode/settings.json: Format-on-save for immediate feedback

**New npm scripts:**
- npm run format: Format entire project
- npm run format:check: Verify formatting without changes
- npm run lint:fix: Auto-fix all ESLint errors
- npm run type-check: Standalone TypeScript validation

**Benefits:**
- Prevents linting errors and broken builds from entering git history
- Consistent code formatting across team (eliminates formatting debates)
- Fast commit times (only checks what changed)
- Scalable approach as project grows

**Documentation:**
- Updated CLAUDE.md with comprehensive Git Hooks section
- Added troubleshooting guide and bypass instructions for emergencies

Dependencies: lint-staged@16.2.7, prettier@3.8.1