### PR TITLE
feat: implement admin permission checks across tournament and match e…

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -13,6 +13,12 @@ Husky + lint-staged + Prettier enforce code quality automatically.
 - TypeScript type checking (`tsc --noEmit`)
 - Full production build (`npm run build`)
 
+## Branch Naming Convention
+
+`<user>/<description>` — e.g., `iakor/34-admin-authorization`
+
+Use kebab-case for the description. Include the issue number as a prefix when the branch addresses a specific GitHub issue.
+
 ## Manual Commands
 
 ```bash

--- a/app/api/admin/reset-incomplete-predictions/route.ts
+++ b/app/api/admin/reset-incomplete-predictions/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextResponse } from "next/server";
 
 /**
@@ -6,6 +7,9 @@ import { NextResponse } from "next/server";
  * This is an admin endpoint to ensure data consistency
  */
 export async function POST() {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const supabase = await createClient();
 

--- a/app/api/matches/[matchId]/route.ts
+++ b/app/api/matches/[matchId]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUTC } from "@/lib/utils/date";
 
@@ -36,19 +37,12 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const supabase = await createClient();
     const { matchId } = await params;
-
-    // Check authentication
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const body = await request.json();
     const {
@@ -129,19 +123,12 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const supabase = await createClient();
     const { matchId } = await params;
-
-    // Check authentication
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     // Check if match has any predictions
     const { data: predictions } = await supabase

--- a/app/api/matches/[matchId]/score/route.ts
+++ b/app/api/matches/[matchId]/score/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 import { calculatePoints } from "@/lib/utils/scoring";
 import { getCurrentUTC } from "@/lib/utils/date";
@@ -7,6 +8,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ matchId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const supabase = await createClient();
     const { matchId } = await params;

--- a/app/api/tournaments/[tournamentId]/route.ts
+++ b/app/api/tournaments/[tournamentId]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUTC } from "@/lib/utils/date";
 
@@ -29,16 +30,12 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ tournamentId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const { tournamentId } = await params;
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const body = await request.json();
     const { name, sport, start_date, end_date, status, scoring_rules } = body;
@@ -71,16 +68,12 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ tournamentId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const { tournamentId } = await params;
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     // Check if tournament has any matches
     const { data: matches, error: matchesError } = await supabase

--- a/app/api/tournaments/[tournamentId]/teams/route.ts
+++ b/app/api/tournaments/[tournamentId]/teams/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 
 // GET all teams for a tournament
@@ -37,16 +38,12 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ tournamentId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const { tournamentId } = await params;
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const body = await request.json();
     const { team_id } = body;
@@ -86,16 +83,12 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ tournamentId: string }> }
 ) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const { tournamentId } = await params;
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const { searchParams } = new URL(request.url);
     const teamId = searchParams.get("teamId");

--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
@@ -20,15 +21,11 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+  const adminError = await checkAdminPermission();
+  if (adminError) return adminError;
+
   try {
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const body = await request.json();
     const { name, sport, start_date, end_date, status, scoring_rules } = body;


### PR DESCRIPTION
 Six API routes performing admin-only operations were missing proper authorization checks. Two had no auth at all
  (unauthenticated callers could trigger them), and four checked only that a user was logged in — not that they were an
  admin.

  This PR applies checkAdminPermission() consistently to all affected handlers, matching the pattern already used in
  correctly-protected routes (e.g., /api/admin/users).