### PR TITLE
fix(security): prevent privilege escalation via users RLS self-update policy

### DIFF
--- a/app/(app)/(user)/(admin)/layout.tsx
+++ b/app/(app)/(user)/(admin)/layout.tsx
@@ -1,6 +1,9 @@
 import { requireAdmin } from "@/lib/utils/admin";
 import { redirect } from "next/navigation";
 
+// This server-side layout is the real security boundary for all admin routes.
+// Any admin UI checks in client components (e.g. hiding buttons) are UX-only —
+// this layout is what actually prevents unauthorized access.
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   try {
     await requireAdmin();

--- a/supabase/migrations/20260301145751_fix_user_self_update_rls_policy.sql
+++ b/supabase/migrations/20260301145751_fix_user_self_update_rls_policy.sql
@@ -1,0 +1,10 @@
+DROP POLICY IF EXISTS "Users can update own profile" ON users;
+
+CREATE POLICY "Users can update own profile" ON users
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (
+    auth.uid() = id
+    AND is_admin = (SELECT is_admin FROM users WHERE id = auth.uid())
+    AND status = (SELECT status FROM users WHERE id = auth.uid())
+  );


### PR DESCRIPTION
## Summary
- Adds `WITH CHECK` clause to the `users` table self-update RLS policy
- Prevents users from modifying `is_admin` or `status` on their own record via direct Supabase REST API calls (bypassing Next.js)
- Uses `IF EXISTS` on the drop to handle schema drift gracefully

Closes #35

## Test plan
- [ ] Verify a regular user JWT cannot PATCH `{ "is_admin": true }` against the Supabase REST API `/rest/v1/users`
- [ ] Verify a regular user can still update their own profile fields (screen name, avatar URL)
- [ ] Verify an admin can still update other users' `is_admin` and `status` via the admin API routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)