### PR TITLE
chore: ignore underscore-prefixed variables in ESLint unused-vars rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {
-      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
 ];


### PR DESCRIPTION
Adds varsIgnorePattern: "^_" alongside the existing argsIgnorePattern so that destructuring discard variables (e.g. `const { foo: _bar, ...rest } = obj`) are not flagged as unused.