### PR TITLE
Sets up full accessibility audit infrastructure with Playwright and

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -57,6 +57,15 @@ Refer to `CLAUDE.md` and `.claude/skills/typescript-conventions.md` for full con
 10. **Error Handling** — try-catch + console.error + status codes in API routes
 11. **Imports** — `@/` aliases required, no server imports in client components
 12. **Scoring Logic** — Verify against point rules in CLAUDE.md
+13. **Accessibility (WCAG 2.1 AA)** — See `.claude/rules/accessibility.md` for the full checklist. Key items:
+    - Page has `<main id="main-content">` and a skip-to-content link
+    - Every `<button>`, link, and Radix `<SelectTrigger>` has an accessible name (`aria-label` or visible label)
+    - All form inputs have a `<label>` or `aria-label` (never placeholder-only)
+    - Tabular data (rankings, standings) uses `<table>` with `<th scope>`
+    - Error messages use `role="alert"`; async status uses `aria-live="polite"`
+    - Decorative icons have `aria-hidden="true"`
+    - Modal/drawer close returns focus to the trigger
+    - New animations respect `prefers-reduced-motion`
 
 ## Output Format
 

--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -1,0 +1,263 @@
+# Accessibility (WCAG 2.1 AA)
+
+All UI code must meet WCAG 2.1 AA. The accessibility audit (issues #48–#51) identified four recurring failure categories. Avoid reintroducing them.
+
+---
+
+## 1. Landmark Elements & Page Structure
+
+Every page must have exactly one `<main>` landmark. Use semantic HTML over `<div>` wrappers.
+
+```tsx
+// ✅ Correct — app/(app)/layout.tsx or page wrapper
+<header>…</header>
+<main id="main-content">
+  {children}
+</main>
+<footer>…</footer>
+
+// ❌ Wrong — bare div wrappers
+<div>{children}</div>
+```
+
+### Skip-to-content link
+
+Every layout that renders a nav must include a skip link as the **first child of `<body>`**:
+
+```tsx
+<a
+  href="#main-content"
+  className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:text-foreground focus:rounded focus:shadow"
+>
+  Skip to main content
+</a>
+```
+
+---
+
+## 2. Interactive Elements Must Have Accessible Names
+
+Every `<button>`, `<a>`, and interactive Radix trigger **must** have a visible label or `aria-label` / `aria-labelledby`.
+
+### Icon-only buttons
+
+```tsx
+// ✅ Correct
+<Button variant="ghost" size="icon" aria-label="Open navigation menu">
+  <Menu className="h-5 w-5" aria-hidden="true" />
+</Button>
+
+// ❌ Wrong — no name, icon not hidden
+<Button variant="ghost" size="icon">
+  <Menu className="h-5 w-5" />
+</Button>
+```
+
+### Radix `<Select>` / `SelectTrigger`
+
+Radix `<Select>` renders a `role="combobox"` button. Without visible text it will fail the `button-name` axe rule (critical, WCAG 4.1.2). Always pass `aria-label` or wrap in a `<label>`:
+
+```tsx
+// ✅ Option A — aria-label on the trigger
+<Select>
+  <SelectTrigger aria-label="Select tournament status">
+    <SelectValue placeholder="Status" />
+  </SelectTrigger>
+  …
+</Select>
+
+// ✅ Option B — associate a visible <label> with htmlFor + id
+<label htmlFor="status-select">Status</label>
+<Select>
+  <SelectTrigger id="status-select">
+    <SelectValue placeholder="Status" />
+  </SelectTrigger>
+  …
+</Select>
+```
+
+### Avatar / user menu triggers
+
+```tsx
+// ✅
+<DropdownMenuTrigger asChild>
+  <Button variant="ghost" size="icon" aria-label={`${userName}'s account menu`}>
+    <Avatar>…</Avatar>
+  </Button>
+</DropdownMenuTrigger>
+```
+
+---
+
+## 3. Form Labels
+
+Every form input must have an associated label. Never rely on `placeholder` as a substitute.
+
+```tsx
+// ✅ Visible label
+<label htmlFor="home-score">Home score</label>
+<Input id="home-score" type="number" … />
+
+// ✅ aria-label when a visible label isn't appropriate
+<Input
+  type="number"
+  aria-label={`${homeTeam.name} predicted score`}
+  …
+/>
+
+// ❌ Placeholder only — not accessible
+<Input type="number" placeholder="0" />
+```
+
+---
+
+## 4. Semantic HTML for Data
+
+Use `<table>` for tabular data (rankings, standings, stats). Do not use div grids for data that has row/column relationships.
+
+```tsx
+// ✅
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Rank</th>
+      <th scope="col">Player</th>
+      <th scope="col">Points</th>
+    </tr>
+  </thead>
+  <tbody>
+    {rankings.map((r) => (
+      <tr key={r.user_id}>
+        <td>{r.rank}</td>
+        <td>{r.screen_name}</td>
+        <td>{r.total_points}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>
+
+// ❌ Div grid — not exposed as a table to screen readers
+<div className="grid grid-cols-3">…</div>
+```
+
+---
+
+## 5. ARIA Live Regions for Errors & Status
+
+Error messages and async status updates must be announced to screen readers.
+
+```tsx
+// ✅ Form error — role="alert" triggers immediate announcement
+{
+  error && (
+    <div role="alert" className="text-destructive text-sm">
+      {error}
+    </div>
+  );
+}
+
+// ✅ Non-urgent status (e.g., loading complete) — use aria-live="polite"
+<div aria-live="polite" aria-atomic="true">
+  {status}
+</div>;
+
+// ❌ Silent error — screen readers won't announce this
+{
+  error && <div className="text-destructive text-sm">{error}</div>;
+}
+```
+
+---
+
+## 6. Decorative Icons
+
+Icons that are purely decorative must be hidden from the accessibility tree. Icons that convey meaning must have a label.
+
+```tsx
+// ✅ Decorative icon (accompanies visible text)
+<Fingerprint className="h-5 w-5" aria-hidden="true" />
+
+// ✅ Meaningful icon (no accompanying text)
+<Star className="h-5 w-5" aria-label="Favorited" />
+
+// ❌ Decorative icon without aria-hidden — pollutes the a11y tree
+<Fingerprint className="h-5 w-5" />
+```
+
+---
+
+## 7. Focus Management
+
+When UI elements open/close (modals, drawers, mobile nav), focus must be managed correctly.
+
+- **On open**: move focus to the first interactive element inside the opened element, or to the container with `autoFocus`.
+- **On close**: return focus to the trigger that opened the element.
+
+Radix `<Dialog>` and `<Sheet>` handle this automatically. For custom implementations:
+
+```tsx
+// Return focus to trigger on close
+const triggerRef = useRef<HTMLButtonElement>(null);
+
+function handleClose() {
+  setOpen(false);
+  triggerRef.current?.focus();
+}
+
+<Button ref={triggerRef} onClick={() => setOpen(true)}>
+  Open menu
+</Button>;
+```
+
+---
+
+## 8. Color Contrast
+
+All text must meet WCAG AA contrast ratios: **4.5:1** for normal text, **3:1** for large text (18pt+ or 14pt+ bold).
+
+- Always verify new color combinations in both light **and dark** modes using a contrast checker before finalizing.
+- Avoid placing `--primary` (blue) text or icons directly on `--primary` backgrounds.
+- Do not use color alone to convey meaning (add icons, labels, or patterns alongside color).
+- The shadcn/ui design tokens in `globals.css` are the source of truth — if a new color is needed, define it there as a CSS variable in both `:root` and `.dark`, not as a raw Tailwind value.
+
+---
+
+## 9. Reduced Motion
+
+Respect the user's operating system motion preference. Wrap CSS animations with a `prefers-reduced-motion` media query.
+
+```css
+/* ✅ In globals.css — wrap all animate-* utilities */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+For JS-driven animations (e.g., Framer Motion), read the preference:
+
+```tsx
+const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+```
+
+---
+
+## Quick Checklist (use during code review)
+
+| #   | Check                                                            |
+| --- | ---------------------------------------------------------------- |
+| 1   | Page has `<main id="main-content">` and a skip link              |
+| 2   | All `<button>` and link elements have an accessible name         |
+| 3   | Radix `<SelectTrigger>` has `aria-label` or associated `<label>` |
+| 4   | All form inputs have a `<label>` or `aria-label`                 |
+| 5   | Tabular data uses `<table>` with `<th scope>`                    |
+| 6   | Error messages use `role="alert"`                                |
+| 7   | Decorative icons have `aria-hidden="true"`                       |
+| 8   | Modal/drawer close returns focus to the trigger                  |
+| 9   | Text contrast checked in both light and dark mode                |
+| 10  | New animations respect `prefers-reduced-motion`                  |

--- a/.claude/skills/typescript-conventions.md
+++ b/.claude/skills/typescript-conventions.md
@@ -191,3 +191,57 @@ await toast.promise(asyncOp(), {
 - Organized by feature: `teams.messages.*`, `matches.messages.*`
 - Namespaced keys: `teams.messages.success.created` not just `created`
 - Server: `getTranslations("rankings")` (async). Client: `useTranslations("predictions")`
+
+## Accessibility (WCAG 2.1 AA)
+
+Full patterns in `.claude/rules/accessibility.md`. Non-negotiable rules per component type:
+
+**Buttons & links**
+
+```tsx
+// Icon-only button — always needs aria-label; icon gets aria-hidden
+<Button size="icon" aria-label="Open menu">
+  <Menu className="h-5 w-5" aria-hidden="true" />
+</Button>
+```
+
+**Radix Select — always add aria-label or a visible <label>**
+
+```tsx
+<Select>
+  <SelectTrigger aria-label="Select tournament status">
+    <SelectValue placeholder="Status" />
+  </SelectTrigger>
+</Select>
+```
+
+**Form inputs — label or aria-label required**
+
+```tsx
+<Input aria-label={`${homeTeam.name} predicted score`} type="number" />
+```
+
+**Error messages — must be announced**
+
+```tsx
+{
+  error && (
+    <div role="alert" className="text-destructive text-sm">
+      {error}
+    </div>
+  );
+}
+```
+
+**Decorative icons — must be hidden**
+
+```tsx
+<Fingerprint className="h-5 w-5" aria-hidden="true" />
+```
+
+**Page structure — required in every layout**
+
+```tsx
+<a href="#main-content" className="sr-only focus:not-sr-only …">Skip to main content</a>
+<main id="main-content">…</main>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ supabase/.env.test
 supabase/.branches
 supabase/.temp
 
+# playwright
+playwright-report/
+test-results/
+__tests__/.auth/
+
 # vercel
 .vercel
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,19 @@ Use **Server Components by default** (data fetching, static rendering). Add `"us
 
 Use `useFeatureToast(namespace)` for all user feedback. Feature-specific keys need no prefix (`toast.success('success.created')`). Common messages use `common:` prefix (`toast.error('common:error.generic')`). See [TOASTS.md](./docs/TOASTS.md) for the full API reference and examples.
 
+## Accessibility
+
+All UI must meet **WCAG 2.1 AA**. See `.claude/rules/accessibility.md` for patterns and anti-patterns. Quick rules:
+
+- Every page needs `<main id="main-content">` and a skip-to-content link
+- Every `<button>`, link, and Radix `<SelectTrigger>` needs an accessible name (`aria-label` or visible label)
+- All form inputs need a `<label>` or `aria-label` — placeholder is never sufficient
+- Tabular data (rankings, standings) uses `<table>` with `<th scope>`
+- Error messages use `role="alert"`; decorative icons use `aria-hidden="true"`
+- Focus must return to the trigger element when a modal or drawer closes
+- New CSS animations must respect `prefers-reduced-motion`
+- Verify color contrast in both light and dark mode before finalizing
+
 ## Best Practices & Conventions
 
 See `.claude/skills/typescript-conventions.md` for the complete TypeScript conventions reference.

--- a/__tests__/accessibility/admin/team-management.spec.ts
+++ b/__tests__/accessibility/admin/team-management.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+test.use({ storageState: path.join(__dirname, "../../.auth/admin.json") });
+
+const LIST_URL = "/teams";
+const NEW_URL = "/teams/new";
+
+test("axe: no WCAG 2.1 AA violations on team list page", async ({ page }, testInfo) => {
+  await page.goto(LIST_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("axe: no WCAG 2.1 AA violations on new team form", async ({ page }, testInfo) => {
+  await page.goto(NEW_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order covers all fields in new team form", async ({ page }) => {
+  await page.goto(NEW_URL);
+  const order = await collectFocusOrder(page, 30);
+  const inputs = order.filter(
+    (o) => o.tag === "input" || o.tag === "select" || o.tag === "textarea"
+  );
+  expect.soft(inputs.length).toBeGreaterThan(0);
+});
+
+test("keyboard: Tab reaches Create Team button", async ({ page }) => {
+  await page.goto(NEW_URL);
+  const order = await collectFocusOrder(page, 20);
+  const submitButton = order.find((o) => o.tag === "button" && /create|save|submit/i.test(o.text));
+  expect.soft(submitButton).toBeDefined();
+});
+
+test("keyboard: Tab reaches Edit/Delete actions on team list", async ({ page }) => {
+  await page.goto(LIST_URL);
+  const order = await collectFocusOrder(page, 50);
+  const actionItems = order.filter((o) => o.tag === "a" || o.tag === "button");
+  expect.soft(actionItems.length).toBeGreaterThan(0);
+});
+
+test("dark mode: axe color contrast on team management page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(LIST_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/admin/tournament-management.spec.ts
+++ b/__tests__/accessibility/admin/tournament-management.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+test.use({ storageState: path.join(__dirname, "../../.auth/admin.json") });
+
+const PAGE_URL = "/tournaments/manage";
+
+test("axe: no WCAG 2.1 AA violations on tournament management page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab reaches Create Tournament button", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 30);
+  const createBtn = order.find(
+    (o) => o.tag === "a" || (o.tag === "button" && /create|new/i.test(o.text))
+  );
+  expect.soft(createBtn).toBeDefined();
+});
+
+test("keyboard: Tab order includes action links for existing tournaments", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 50);
+  const actionItems = order.filter((o) => o.tag === "a" || o.tag === "button");
+  expect.soft(actionItems.length).toBeGreaterThan(0);
+});
+
+test("axe: no violations on new tournament form", async ({ page }, testInfo) => {
+  await page.goto(`${PAGE_URL}/new`);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order covers all fields in new tournament form", async ({ page }) => {
+  await page.goto(`${PAGE_URL}/new`);
+  const order = await collectFocusOrder(page, 30);
+  const inputs = order.filter(
+    (o) => o.tag === "input" || o.tag === "select" || o.tag === "textarea"
+  );
+  expect.soft(inputs.length).toBeGreaterThan(0);
+});
+
+test("dark mode: axe color contrast on tournament management page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/admin/users.spec.ts
+++ b/__tests__/accessibility/admin/users.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+// Use admin session for all tests in this file
+test.use({ storageState: path.join(__dirname, "../../.auth/admin.json") });
+
+const PAGE_URL = "/admin/users";
+
+test("axe: no WCAG 2.1 AA violations on admin users page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order reaches action buttons for each user row", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 60);
+  const buttons = order.filter((o) => o.tag === "button");
+  expect.soft(buttons.length).toBeGreaterThan(0);
+});
+
+test("keyboard: deactivation AlertDialog is keyboard accessible", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Find a deactivate button for any non-admin user
+  const deactivateButton = page.getByRole("button", { name: /deactivate/i }).first();
+  const isVisible = await deactivateButton.isVisible().catch(() => false);
+  if (!isVisible) return; // No deactivatable users in seed
+
+  await deactivateButton.click();
+  const dialog = page.getByRole("alertdialog").or(page.getByRole("dialog")).first();
+  await expect.soft(dialog).toBeVisible({ timeout: 3_000 });
+
+  // Focus should be inside the dialog
+  const focusInDialog = await dialog.locator(":focus").count();
+  expect.soft(focusInDialog).toBeGreaterThan(0);
+
+  // Cancel via Escape
+  await page.keyboard.press("Escape");
+  await expect.soft(dialog).toBeHidden({ timeout: 2_000 });
+});
+
+test("keyboard: Tab reaches confirm button inside deactivation dialog", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const deactivateButton = page.getByRole("button", { name: /deactivate/i }).first();
+  const isVisible = await deactivateButton.isVisible().catch(() => false);
+  if (!isVisible) return;
+
+  await deactivateButton.click();
+  const dialog = page.getByRole("alertdialog").or(page.getByRole("dialog")).first();
+  await expect.soft(dialog).toBeVisible({ timeout: 3_000 });
+
+  // Tab to confirm button
+  await page.keyboard.press("Tab");
+  const confirmButton = page.getByRole("button", { name: /confirm|yes|deactivate/i }).first();
+  const isFocused = await confirmButton.evaluate((el) => el === document.activeElement);
+  expect.soft(isFocused).toBe(true);
+});
+
+test("dark mode: axe color contrast on admin users page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/app/matches.spec.ts
+++ b/__tests__/accessibility/app/matches.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+import { getFirstTournamentFromPage } from "../helpers/seed";
+
+let tournamentId: string | null = null;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  tournamentId = await getFirstTournamentFromPage(page);
+  await page.close();
+});
+
+test("axe: no WCAG 2.1 AA violations on matches page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/matches`);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: match cards are focusable via Tab", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/matches`);
+  const order = await collectFocusOrder(page, 40);
+  const interactiveItems = order.filter((o) => o.tag === "a" || o.tag === "button");
+  expect.soft(interactiveItems.length).toBeGreaterThan(0);
+});
+
+test("accessibility: team logo images have alt text", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/matches`);
+  const images = page.locator("img");
+  const count = await images.count();
+  for (let i = 0; i < count; i++) {
+    const img = images.nth(i);
+    const alt = await img.getAttribute("alt");
+    const ariaHidden = await img.getAttribute("aria-hidden");
+    // Image must have alt text OR be explicitly aria-hidden (decorative)
+    const isAccessible = alt !== null || ariaHidden === "true";
+    expect.soft(isAccessible).toBe(true);
+  }
+});
+
+test("dark mode: axe color contrast on matches page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`/tournaments/${tournamentId}/matches`);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/app/predictions.spec.ts
+++ b/__tests__/accessibility/app/predictions.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+import { getFirstTournamentFromPage } from "../helpers/seed";
+
+let tournamentId: string | null = null;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  tournamentId = await getFirstTournamentFromPage(page);
+  await page.close();
+});
+
+test("axe: no WCAG 2.1 AA violations on predictions page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/predictions`);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("finding A03: score inputs have no label or aria-label", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/predictions`);
+
+  // Find all number inputs (score fields in the prediction form)
+  const numberInputs = page.locator('input[type="number"]');
+  const count = await numberInputs.count();
+
+  if (count === 0) {
+    // No active matches with prediction forms — skip
+    return;
+  }
+
+  for (let i = 0; i < count; i++) {
+    const input = numberInputs.nth(i);
+    const id = await input.getAttribute("id");
+    const ariaLabel = await input.getAttribute("aria-label");
+    const ariaLabelledBy = await input.getAttribute("aria-labelledby");
+
+    // Check for associated <label> via htmlFor
+    let hasLabel = false;
+    if (id) {
+      const labelCount = await page.locator(`label[for="${id}"]`).count();
+      hasLabel = labelCount > 0;
+    }
+
+    const hasAccessibleName = hasLabel || !!ariaLabel || !!ariaLabelledBy;
+    // Expected to FAIL for home/away score inputs — Finding A03
+    expect.soft(hasAccessibleName).toBe(true);
+  }
+});
+
+test("keyboard: Tab order goes home score → away score → submit", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/predictions`);
+  const order = await collectFocusOrder(page, 50);
+
+  const numberInputIndices = order
+    .map((o, i) => (o.tag === "input" ? i : -1))
+    .filter((i) => i >= 0);
+
+  if (numberInputIndices.length >= 2) {
+    // First two inputs should be score fields; they should be consecutive or near-consecutive
+    expect.soft(numberInputIndices[1] - numberInputIndices[0]).toBeLessThanOrEqual(3);
+  }
+});
+
+test("keyboard: locked prediction inputs are skipped by Tab", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/predictions`);
+
+  // Disabled inputs should not appear in Tab order
+  const disabledInputs = page.locator("input[disabled]");
+  const count = await disabledInputs.count();
+
+  if (count === 0) return; // No locked matches
+
+  for (let i = 0; i < count; i++) {
+    const input = disabledInputs.nth(i);
+    // Disabled inputs must not receive focus
+    await input.focus().catch(() => {});
+    const focused = await page.evaluate(() => document.activeElement?.getAttribute("disabled"));
+    expect.soft(focused).toBeNull();
+  }
+});
+
+test("dark mode: axe color contrast on predictions page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`/tournaments/${tournamentId}/predictions`);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/app/profile.spec.ts
+++ b/__tests__/accessibility/app/profile.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+const PAGE_URL = "/profile";
+
+test("axe: no WCAG 2.1 AA violations on profile page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order reaches all profile form fields", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 30);
+  const inputs = order.filter((o) => o.tag === "input" || o.tag === "textarea");
+  expect.soft(inputs.length).toBeGreaterThan(0);
+});
+
+test("finding A08: decorative icons are aria-hidden", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // SVG icons used decoratively should be aria-hidden
+  const svgs = page.locator("svg");
+  const count = await svgs.count();
+  let decorativeWithoutHidden = 0;
+  for (let i = 0; i < count; i++) {
+    const svg = svgs.nth(i);
+    const ariaHidden = await svg.getAttribute("aria-hidden");
+    const ariaLabel = await svg.getAttribute("aria-label");
+    const role = await svg.getAttribute("role");
+    const title = await svg.locator("title").count();
+    // Decorative SVG: no accessible name and no aria-hidden
+    const hasAccessibleName = !!ariaLabel || role === "img" || title > 0;
+    if (!hasAccessibleName && ariaHidden !== "true") {
+      decorativeWithoutHidden++;
+    }
+  }
+  // Documents Finding A08: decorative icons should be aria-hidden
+  expect.soft(decorativeWithoutHidden).toBe(0);
+});
+
+test("keyboard: AlertDialog (deactivation) traps focus correctly", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Find a button that opens a destructive/deactivation dialog
+  const dangerButton = page.getByRole("button", { name: /deactivate|delete account/i }).first();
+  const hasDangerButton = await dangerButton.isVisible().catch(() => false);
+  if (!hasDangerButton) return; // Feature not on this page for this user
+
+  await dangerButton.click();
+  const dialog = page.getByRole("alertdialog").or(page.getByRole("dialog")).first();
+  await expect.soft(dialog).toBeVisible({ timeout: 3_000 });
+
+  // Tab inside dialog — focus must stay within the dialog
+  await page.keyboard.press("Tab");
+  const focused = page.locator(":focus");
+  const isInDialog = await dialog.locator(":focus").count();
+  expect.soft(isInDialog).toBeGreaterThan(0);
+
+  // Escape should close the dialog
+  await page.keyboard.press("Escape");
+  await expect.soft(dialog).toBeHidden({ timeout: 2_000 });
+});
+
+test("prefers-reduced-motion: animated elements have 0s duration", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto(PAGE_URL);
+  const animatedEl = page.locator('[class*="animate-"]').first();
+  const count = await animatedEl.count();
+  if (count === 0) return;
+  const duration = await animatedEl.evaluate((el) => getComputedStyle(el).animationDuration);
+  expect.soft(duration).toBe("0s"); // Documents Finding A09
+});
+
+test("dark mode: axe color contrast on profile page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/app/rankings.spec.ts
+++ b/__tests__/accessibility/app/rankings.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+import { getFirstTournamentFromPage } from "../helpers/seed";
+
+let tournamentId: string | null = null;
+
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  tournamentId = await getFirstTournamentFromPage(page);
+  await page.close();
+});
+
+test("axe: no WCAG 2.1 AA violations on rankings page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/rankings`);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("finding A04: rankings uses div-based layout instead of semantic table", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/rankings`);
+
+  // Check whether a semantic <table> element is present
+  const tableCount = await page.locator("table").count();
+  // Expected to FAIL — Finding A04: div layout instead of <table>
+  expect.soft(tableCount).toBeGreaterThan(0);
+
+  // Additionally, axe should flag the missing table/landmark role
+  // (already captured in the axe scan above)
+});
+
+test("keyboard: ranking row links are focusable via Tab", async ({ page }) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.goto(`/tournaments/${tournamentId}/rankings`);
+  const order = await collectFocusOrder(page, 40);
+  const linkItems = order.filter((o) => o.tag === "a");
+  // Each player row should be a link or contain a link
+  expect.soft(linkItems.length).toBeGreaterThan(0);
+});
+
+test("dark mode: axe color contrast on rankings page", async ({ page }, testInfo) => {
+  if (!tournamentId) {
+    test.skip(true, "No tournament found in seed data");
+    return;
+  }
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`/tournaments/${tournamentId}/rankings`);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/app/tournaments.spec.ts
+++ b/__tests__/accessibility/app/tournaments.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+const PAGE_URL = "/tournaments";
+
+test("axe: no WCAG 2.1 AA violations on tournaments page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("finding A01: tournaments page is missing landmark elements", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Assert that <main> landmark is absent — documents Finding A01
+  const mainCount = await page.locator("main").count();
+  expect.soft(mainCount).toBeGreaterThan(0); // Expected to FAIL — Finding A01
+});
+
+test("finding A02: no skip-to-content link", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // The first Tab press should land on a skip link
+  await page.keyboard.press("Tab");
+  const focused = page.locator(":focus");
+  const text = await focused.innerText().catch(() => "");
+  const isSkipLink = /skip|jump to/i.test(text);
+  expect.soft(isSkipLink).toBe(true); // Expected to FAIL — Finding A02
+});
+
+test("keyboard: tournament card links have discernible text", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const links = page.locator('a[href*="/tournaments/"]');
+  const count = await links.count();
+  if (count === 0) {
+    // No tournaments in seed — skip assertion
+    return;
+  }
+  for (let i = 0; i < count; i++) {
+    const link = links.nth(i);
+    const text = await link.innerText().catch(() => "");
+    const ariaLabel = await link.getAttribute("aria-label");
+    const ariaLabelledBy = await link.getAttribute("aria-labelledby");
+    const hasAccessibleName = text.trim().length > 0 || !!ariaLabel || !!ariaLabelledBy;
+    expect.soft(hasAccessibleName).toBe(true);
+  }
+});
+
+test("keyboard: Tab order cycles through card links", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 30);
+  const linkItems = order.filter((o) => o.tag === "a");
+  expect.soft(linkItems.length).toBeGreaterThan(0);
+});
+
+test("dark mode: axe color contrast on tournaments page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});
+
+test("prefers-reduced-motion: animate-* elements have 0s duration", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto(PAGE_URL);
+  const animatedEl = page.locator('[class*="animate-"]').first();
+  const count = await animatedEl.count();
+  if (count === 0) return; // No animated elements on this page
+  const duration = await animatedEl.evaluate((el) => getComputedStyle(el).animationDuration);
+  // Documents Finding A09: expected "0s" if prefers-reduced-motion is respected
+  expect.soft(duration).toBe("0s");
+});

--- a/__tests__/accessibility/auth/forgot-password.spec.ts
+++ b/__tests__/accessibility/auth/forgot-password.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const PAGE_URL = "/forgot-password";
+
+test("axe: no WCAG 2.1 AA violations on forgot-password page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order reaches email field and submit button", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 15);
+  const tags = order.map((o) => o.tag);
+  expect.soft(tags).toContain("input");
+  expect.soft(tags).toContain("button");
+});
+
+test("keyboard: Enter submits form from email field", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const emailInput = page.getByLabel(/email/i);
+  await emailInput.fill("test@example.com");
+  await emailInput.press("Enter");
+  // Should show a success state or stay on page — just confirm no crash
+  await page.waitForTimeout(1000);
+  const url = page.url();
+  expect.soft(url).toContain("forgot-password");
+});
+
+test("dark mode: axe color contrast on forgot-password page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/auth/login.spec.ts
+++ b/__tests__/accessibility/auth/login.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+// Run as anonymous (no stored session)
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const PAGE_URL = "/login";
+
+test("axe: no WCAG 2.1 AA violations on login page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: all form fields are reachable via Tab", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 20);
+  const tags = order.map((o) => o.tag);
+  // Expect at least one input and one button in the Tab order
+  expect.soft(tags).toContain("input");
+  expect.soft(tags).toContain("button");
+});
+
+test("keyboard: Tab order reaches email → passkey button → password → submit", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 20);
+  const emailIdx = order.findIndex((o) => o.tag === "input" && o.ariaLabel === null);
+  const submitIdx = order.findIndex((o) => o.tag === "button" && /log in|sign in/i.test(o.text));
+  expect.soft(emailIdx).toBeGreaterThanOrEqual(0);
+  expect.soft(submitIdx).toBeGreaterThan(emailIdx);
+});
+
+test("finding A06: login error div has no role=alert", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Trigger an error by submitting with wrong credentials
+  await page.getByLabel(/email/i).fill("wrong@example.com");
+  await page.getByLabel(/password/i).fill("wrongpassword");
+  await page.getByRole("button", { name: /log in|sign in/i }).click();
+  // Wait for error to appear
+  await page
+    .locator(".text-destructive")
+    .waitFor({ timeout: 8_000 })
+    .catch(() => {});
+  const errorDiv = page.locator(".text-destructive").first();
+  const isVisible = await errorDiv.isVisible().catch(() => false);
+  if (isVisible) {
+    const role = await errorDiv.getAttribute("role");
+    // DOCUMENT the finding: error div should have role="alert" but does not
+    expect.soft(role).toBe("alert"); // Expected to FAIL — Finding A06
+  }
+});
+
+test("keyboard: Enter submits form from password field", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  await page.getByLabel(/email/i).fill("player1@quiniela.test");
+  await page.getByLabel(/password/i).fill("password123");
+  await page.getByLabel(/password/i).press("Enter");
+  // Either redirected or migration prompt shown — either means form submitted
+  await Promise.race([
+    page.waitForURL("**/tournaments", { timeout: 10_000 }),
+    page.getByRole("button", { name: /skip/i }).waitFor({ timeout: 8_000 }),
+  ]).catch(() => {});
+  const url = page.url();
+  expect.soft(url).not.toContain("/login");
+});
+
+test("keyboard: LanguageSwitcher is keyboard operable", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Tab to the language switcher trigger button
+  const langButton = page.getByRole("button", { name: /language|en|es|english|spanish/i }).first();
+  await langButton.focus();
+  await page.keyboard.press("Enter");
+  // Dropdown/popover should appear
+  const menu = page.getByRole("listbox").or(page.getByRole("menu")).first();
+  await expect.soft(menu).toBeVisible({ timeout: 3_000 });
+  // Escape should close it
+  await page.keyboard.press("Escape");
+  await expect.soft(menu).toBeHidden({ timeout: 2_000 });
+});
+
+test("dark mode: axe color contrast on login page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/auth/signup.spec.ts
+++ b/__tests__/accessibility/auth/signup.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const PAGE_URL = "/signup";
+
+test("axe: no WCAG 2.1 AA violations on signup page", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("keyboard: Tab order reaches all form fields and submit", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 20);
+  const tags = order.map((o) => o.tag);
+  expect.soft(tags.filter((t) => t === "input").length).toBeGreaterThanOrEqual(3);
+  expect.soft(tags).toContain("button");
+});
+
+test("keyboard: Enter submits signup form from last field", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Fill form fields
+  await page.getByLabel(/email/i).fill(`test-a11y-${Date.now()}@example.com`);
+  const screenNameInput = page
+    .getByLabel(/screen name|display name|username/i)
+    .first()
+    .or(page.locator('input[type="text"]').first());
+  await screenNameInput.fill("A11yTester");
+  await page.getByLabel(/password/i).fill("password123");
+  await page.getByLabel(/password/i).press("Enter");
+  // Should redirect away from /signup
+  await page
+    .waitForURL((url) => !url.pathname.includes("/signup"), { timeout: 10_000 })
+    .catch(() => {});
+  // We don't assert the redirect strictly because we used a fake email;
+  // the point is the Enter key triggered submission
+});
+
+test("dark mode: axe color contrast on signup page", async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(PAGE_URL);
+  const results = await runAxe(page, testInfo);
+  const contrastViolations = results.violations.filter((v) => v.id === "color-contrast");
+  expect.soft(contrastViolations).toHaveLength(0);
+});

--- a/__tests__/accessibility/fixtures/auth.setup.ts
+++ b/__tests__/accessibility/fixtures/auth.setup.ts
@@ -54,34 +54,47 @@ async function loginViaApi(
     expires_in: number;
   };
 
-  // 2. Navigate to the app so cookies are set in the right origin
-  await page.goto("/login");
-  await page.waitForLoadState("domcontentloaded");
+  // 2. Inject the session as cookies — @supabase/ssr reads cookies, not localStorage.
+  //    The cookie name follows the pattern: sb-<project-ref>-auth-token
+  //    Long values are chunked as .0, .1, etc. by the library, but we write the
+  //    full value here; the middleware will re-chunk on first response.
+  const projectRef = new URL(SUPABASE_URL).hostname.split(".")[0];
+  const cookieName = `sb-${projectRef}-auth-token`;
+  const cookieValue = JSON.stringify({
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_in: session.expires_in,
+    expires_at: Math.floor(Date.now() / 1000) + session.expires_in,
+    token_type: "bearer",
+  });
 
-  // 3. Inject the Supabase session via the browser's Supabase client
-  //    @supabase/ssr reads the session from cookies; we set it via the client
-  //    so the library handles cookie-chunking correctly.
-  await page.evaluate(
-    ({ url, key, accessToken, refreshToken }) => {
-      // Use the Supabase global if available, otherwise set the raw storage key
-      const storageKey = `sb-${new URL(url).hostname.split(".")[0]}-auth-token`;
-      const sessionData = JSON.stringify({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-        token_type: "bearer",
-      });
-      localStorage.setItem(storageKey, sessionData);
-    },
-    {
-      url: SUPABASE_URL,
-      key: SUPABASE_ANON_KEY,
-      accessToken: session.access_token,
-      refreshToken: session.refresh_token,
-    }
-  );
+  // Chunk the cookie value into 3600-byte pieces (Supabase SSR default)
+  const chunkSize = 3600;
+  const chunks: string[] = [];
+  for (let i = 0; i < cookieValue.length; i += chunkSize) {
+    chunks.push(cookieValue.slice(i, i + chunkSize));
+  }
 
-  // 4. Navigate to /tournaments — the app middleware will exchange localStorage
-  //    tokens for proper cookies and redirect if authenticated.
+  const baseURL = "http://localhost:3000";
+  if (chunks.length === 1) {
+    await page
+      .context()
+      .addCookies([
+        { name: cookieName, value: chunks[0], url: baseURL, httpOnly: false, sameSite: "Lax" },
+      ]);
+  } else {
+    await page.context().addCookies(
+      chunks.map((chunk, i) => ({
+        name: `${cookieName}.${i}`,
+        value: chunk,
+        url: baseURL,
+        httpOnly: false,
+        sameSite: "Lax" as const,
+      }))
+    );
+  }
+
+  // 3. Navigate to /tournaments — the middleware will see the session cookies.
   await page.goto("/tournaments");
   await page.waitForURL("**/tournaments", { timeout: 15_000 });
   await expect(page).toHaveURL(/\/tournaments/);

--- a/__tests__/accessibility/fixtures/auth.setup.ts
+++ b/__tests__/accessibility/fixtures/auth.setup.ts
@@ -1,0 +1,98 @@
+import { test as setup, expect } from "@playwright/test";
+import path from "path";
+
+const USER_FILE = path.join(__dirname, "../../.auth/user.json");
+const ADMIN_FILE = path.join(__dirname, "../../.auth/admin.json");
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+const ADMIN_EMAIL = process.env.TEST_ADMIN_EMAIL ?? "";
+const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD ?? "";
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY in .env.local"
+  );
+}
+if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+  throw new Error("Missing TEST_ADMIN_EMAIL or TEST_ADMIN_PASSWORD in .env.local");
+}
+
+/**
+ * Authenticates directly via the Supabase REST API (bypasses the login UI).
+ * This is far more reliable in CI/headless environments than driving the form.
+ *
+ * After getting tokens, navigates to /tournaments so the app's middleware can
+ * exchange them for session cookies, then saves storageState.
+ */
+async function loginViaApi(
+  page: import("@playwright/test").Page,
+  email: string,
+  password: string,
+  storagePath: string
+) {
+  // 1. Get session tokens from Supabase Auth REST API
+  const res = await page.request.post(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      "Content-Type": "application/json",
+    },
+    data: { email, password },
+  });
+
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(
+      `Supabase auth failed for ${email} (${res.status()}): ${body}\n` +
+        "Ensure the account exists in your Supabase project."
+    );
+  }
+
+  const session = (await res.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  };
+
+  // 2. Navigate to the app so cookies are set in the right origin
+  await page.goto("/login");
+  await page.waitForLoadState("domcontentloaded");
+
+  // 3. Inject the Supabase session via the browser's Supabase client
+  //    @supabase/ssr reads the session from cookies; we set it via the client
+  //    so the library handles cookie-chunking correctly.
+  await page.evaluate(
+    ({ url, key, accessToken, refreshToken }) => {
+      // Use the Supabase global if available, otherwise set the raw storage key
+      const storageKey = `sb-${new URL(url).hostname.split(".")[0]}-auth-token`;
+      const sessionData = JSON.stringify({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        token_type: "bearer",
+      });
+      localStorage.setItem(storageKey, sessionData);
+    },
+    {
+      url: SUPABASE_URL,
+      key: SUPABASE_ANON_KEY,
+      accessToken: session.access_token,
+      refreshToken: session.refresh_token,
+    }
+  );
+
+  // 4. Navigate to /tournaments — the app middleware will exchange localStorage
+  //    tokens for proper cookies and redirect if authenticated.
+  await page.goto("/tournaments");
+  await page.waitForURL("**/tournaments", { timeout: 15_000 });
+  await expect(page).toHaveURL(/\/tournaments/);
+
+  await page.context().storageState({ path: storagePath });
+}
+
+setup("authenticate as user", async ({ page }) => {
+  await loginViaApi(page, ADMIN_EMAIL, ADMIN_PASSWORD, USER_FILE);
+});
+
+setup("authenticate as admin", async ({ page }) => {
+  await loginViaApi(page, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_FILE);
+});

--- a/__tests__/accessibility/helpers/axe.ts
+++ b/__tests__/accessibility/helpers/axe.ts
@@ -1,0 +1,32 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page, TestInfo } from "@playwright/test";
+import type { AxeResults } from "axe-core";
+
+/**
+ * Runs an axe-core scan on the current page.
+ * Attaches the full JSON results to the Playwright HTML report.
+ * Returns the AxeResults object so tests can assert on violations.
+ *
+ * All WCAG 2.1 AA rules are enabled by default.
+ */
+export async function runAxe(page: Page, testInfo: TestInfo): Promise<AxeResults> {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  // Attach raw JSON so the HTML report includes full violation details
+  await testInfo.attach("axe-results", {
+    body: JSON.stringify(results, null, 2),
+    contentType: "application/json",
+  });
+
+  return results;
+}
+
+/**
+ * Filters axe violations by rule ID.
+ * Useful for asserting known issues without failing on unrelated rules.
+ */
+export function filterViolations(results: AxeResults, ruleIds: string[]) {
+  return results.violations.filter((v) => ruleIds.includes(v.id));
+}

--- a/__tests__/accessibility/helpers/keyboard.ts
+++ b/__tests__/accessibility/helpers/keyboard.ts
@@ -1,0 +1,62 @@
+import type { Page, Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Presses Tab `count` times and returns the locator of the final focused element.
+ */
+export async function tabThrough(page: Page, count: number): Promise<Locator> {
+  for (let i = 0; i < count; i++) {
+    await page.keyboard.press("Tab");
+  }
+  return page.locator(":focus");
+}
+
+/**
+ * Asserts that the currently focused element has a visible focus ring.
+ * Checks for a non-zero outline width or box-shadow that indicates focus styling.
+ */
+export async function expectVisibleFocusRing(page: Page): Promise<void> {
+  const focusedEl = page.locator(":focus");
+  const outlineWidth = await focusedEl.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return parseFloat(style.outlineWidth);
+  });
+  const boxShadow = await focusedEl.evaluate((el) => getComputedStyle(el).boxShadow);
+
+  const hasFocusRing = outlineWidth > 0 || (boxShadow !== "none" && boxShadow !== "");
+  expect.soft(hasFocusRing).toBe(true);
+}
+
+/**
+ * Tabs through all focusable elements on the page, collecting their
+ * accessible names and tag names. Stops when focus loops back to the start
+ * or after `maxTabs` iterations.
+ */
+export async function collectFocusOrder(
+  page: Page,
+  maxTabs = 50
+): Promise<Array<{ tag: string; text: string; ariaLabel: string | null }>> {
+  // Focus the first interactive element
+  await page.keyboard.press("Tab");
+
+  const order: Array<{ tag: string; text: string; ariaLabel: string | null }> = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < maxTabs; i++) {
+    const info = await page.locator(":focus").evaluate((el) => ({
+      tag: el.tagName.toLowerCase(),
+      text: (el as HTMLElement).innerText?.trim().slice(0, 80) || "",
+      ariaLabel: el.getAttribute("aria-label"),
+      id: el.id || el.getAttribute("data-testid") || "",
+    }));
+
+    const key = `${info.tag}:${info.text}:${info.ariaLabel}`;
+    if (seen.has(key) && i > 0) break; // Focus looped
+    seen.add(key);
+
+    order.push({ tag: info.tag, text: info.text, ariaLabel: info.ariaLabel });
+    await page.keyboard.press("Tab");
+  }
+
+  return order;
+}

--- a/__tests__/accessibility/helpers/seed.ts
+++ b/__tests__/accessibility/helpers/seed.ts
@@ -1,0 +1,39 @@
+import type { Page } from "@playwright/test";
+
+export interface TournamentInfo {
+  id: string;
+  name: string;
+}
+
+export interface MatchInfo {
+  id: string;
+  tournamentId: string;
+}
+
+/**
+ * Fetches the first available tournament from the app's API.
+ * Requires the page to be authenticated.
+ */
+export async function getFirstTournament(page: Page): Promise<TournamentInfo | null> {
+  const response = await page.request.get("/api/tournaments");
+  if (!response.ok()) return null;
+  const data = await response.json();
+  const tournaments: Array<{ id: string; name: string }> = Array.isArray(data)
+    ? data
+    : data.tournaments || [];
+  return tournaments[0] ?? null;
+}
+
+/**
+ * Navigates to /tournaments and extracts the first tournament ID from the page links.
+ * Falls back to scraping the DOM when no API endpoint is available.
+ */
+export async function getFirstTournamentFromPage(page: Page): Promise<string | null> {
+  await page.goto("/tournaments");
+  const link = page.locator('a[href*="/tournaments/"][href$="/matches"]').first();
+  const href = await link.getAttribute("href").catch(() => null);
+  if (!href) return null;
+  // e.g. /tournaments/abc-123/matches → abc-123
+  const match = href.match(/\/tournaments\/([^/]+)\//);
+  return match?.[1] ?? null;
+}

--- a/__tests__/accessibility/reports/generate-summary.ts
+++ b/__tests__/accessibility/reports/generate-summary.ts
@@ -1,0 +1,384 @@
+#!/usr/bin/env tsx
+/**
+ * generate-summary.ts
+ *
+ * Reads test-results/results.json (Playwright JSON reporter output) and
+ * extracts embedded axe-core JSON attachments from each test result.
+ * Produces audit-report.md in the project root.
+ *
+ * Usage:
+ *   tsx __tests__/accessibility/reports/generate-summary.ts
+ *   npm run audit:a11y:summary
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface AxeViolation {
+  id: string;
+  impact: "critical" | "serious" | "moderate" | "minor" | null;
+  description: string;
+  helpUrl: string;
+  nodes: Array<{ html: string; failureSummary: string }>;
+}
+
+interface AxeResults {
+  url: string;
+  violations: AxeViolation[];
+  passes: unknown[];
+  incomplete: unknown[];
+}
+
+interface PlaywrightAttachment {
+  name: string;
+  contentType: string;
+  body?: string;
+  path?: string;
+}
+
+interface PlaywrightTestResult {
+  status: string;
+  attachments?: PlaywrightAttachment[];
+  error?: { message: string };
+}
+
+interface PlaywrightTest {
+  title: string;
+  status?: string;
+  results?: PlaywrightTestResult[];
+  tests?: PlaywrightTest[];
+  suites?: PlaywrightTest[];
+}
+
+interface PlaywrightReport {
+  suites: PlaywrightTest[];
+  stats: {
+    expected: number;
+    unexpected: number;
+    skipped: number;
+    flaky: number;
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const RESULTS_PATH = path.join(process.cwd(), "test-results", "results.json");
+const OUTPUT_PATH = path.join(process.cwd(), "audit-report.md");
+
+function readResultsJson(): PlaywrightReport | null {
+  if (!fs.existsSync(RESULTS_PATH)) {
+    console.error(`❌  ${RESULTS_PATH} not found. Run 'npm run audit:a11y' first.`);
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(RESULTS_PATH, "utf-8")) as PlaywrightReport;
+}
+
+/** Recursively walks the test suite tree and returns all leaf tests. */
+function collectTests(node: PlaywrightTest): PlaywrightTest[] {
+  const tests: PlaywrightTest[] = [];
+  if (node.results) tests.push(node);
+  for (const child of node.tests ?? []) tests.push(...collectTests(child));
+  for (const child of node.suites ?? []) tests.push(...collectTests(child));
+  return tests;
+}
+
+/** Extracts axe JSON attachments from a test's results. */
+function extractAxeResults(test: PlaywrightTest): AxeResults[] {
+  const axeResults: AxeResults[] = [];
+  for (const result of test.results ?? []) {
+    for (const attachment of result.attachments ?? []) {
+      if (attachment.name === "axe-results" && attachment.contentType === "application/json") {
+        try {
+          const raw = attachment.body
+            ? Buffer.from(attachment.body, "base64").toString("utf-8")
+            : attachment.path
+              ? fs.readFileSync(attachment.path, "utf-8")
+              : null;
+          if (raw) axeResults.push(JSON.parse(raw) as AxeResults);
+        } catch {
+          // Skip malformed attachments
+        }
+      }
+    }
+  }
+  return axeResults;
+}
+
+/** Groups violations by WCAG criterion derived from helpUrl tags. */
+interface ViolationSummary {
+  id: string;
+  impact: string;
+  description: string;
+  helpUrl: string;
+  pages: string[];
+  occurrences: number;
+}
+
+function aggregateViolations(
+  allResults: Array<{ url: string; violations: AxeViolation[] }>
+): ViolationSummary[] {
+  const map = new Map<string, ViolationSummary>();
+  for (const { url, violations } of allResults) {
+    for (const v of violations) {
+      const existing = map.get(v.id);
+      if (existing) {
+        existing.occurrences += v.nodes.length;
+        if (!existing.pages.includes(url)) existing.pages.push(url);
+      } else {
+        map.set(v.id, {
+          id: v.id,
+          impact: v.impact ?? "unknown",
+          description: v.description,
+          helpUrl: v.helpUrl,
+          pages: [url],
+          occurrences: v.nodes.length,
+        });
+      }
+    }
+  }
+  // Sort by impact: critical > serious > moderate > minor
+  const IMPACT_ORDER = ["critical", "serious", "moderate", "minor", "unknown"];
+  return [...map.values()].sort(
+    (a, b) => IMPACT_ORDER.indexOf(a.impact) - IMPACT_ORDER.indexOf(b.impact)
+  );
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+function main() {
+  const report = readResultsJson();
+  if (!report) process.exit(1);
+
+  const allTests = report.suites.flatMap(collectTests);
+
+  // Collect all axe results across every test
+  const allAxeResults: Array<{ url: string; violations: AxeViolation[] }> = [];
+  const keyboardFindings: Array<{ test: string; status: string; detail: string }> = [];
+
+  for (const t of allTests) {
+    const axe = extractAxeResults(t);
+    for (const a of axe) {
+      allAxeResults.push({ url: a.url, violations: a.violations });
+    }
+
+    // Capture keyboard navigation findings from failed tests
+    const isKeyboardTest = /keyboard|focus|tab|finding a0/i.test(t.title);
+    if (isKeyboardTest) {
+      const status = t.results?.[0]?.status ?? "unknown";
+      const errorMsg = t.results?.[0]?.error?.message ?? "";
+      if (status === "failed" || status === "unexpected") {
+        keyboardFindings.push({ test: t.title, status, detail: errorMsg.slice(0, 200) });
+      }
+    }
+  }
+
+  const violations = aggregateViolations(allAxeResults);
+  const criticalCount = violations.filter((v) => v.impact === "critical").length;
+  const seriousCount = violations.filter((v) => v.impact === "serious").length;
+  const moderateCount = violations.filter((v) => v.impact === "moderate").length;
+  const minorCount = violations.filter((v) => v.impact === "minor").length;
+  const totalTests = allTests.length;
+  const passed = allTests.filter((t) => t.results?.[0]?.status === "passed").length;
+  const failed = allTests.filter(
+    (t) => t.results?.[0]?.status === "failed" || t.results?.[0]?.status === "unexpected"
+  ).length;
+  const skipped = allTests.filter((t) => t.results?.[0]?.status === "skipped").length;
+
+  // Per-page summary
+  const pageMap = new Map<string, { violations: number; hasCritical: boolean }>();
+  for (const { url, violations: vs } of allAxeResults) {
+    const page = url.replace(/^https?:\/\/[^/]+/, "") || "/";
+    const existing = pageMap.get(page) ?? { violations: 0, hasCritical: false };
+    existing.violations += vs.length;
+    existing.hasCritical = existing.hasCritical || vs.some((v) => v.impact === "critical");
+    pageMap.set(page, existing);
+  }
+
+  // ── Build Markdown ────────────────────────────────────────────────────────
+
+  const now = new Date().toISOString().split("T")[0];
+  const lines: string[] = [];
+
+  lines.push(`# Quiniela Accessibility Audit Report`);
+  lines.push(``);
+  lines.push(`**Generated:** ${now}  `);
+  lines.push(`**Standard:** WCAG 2.1 AA  `);
+  lines.push(`**Tool:** Playwright + axe-core  `);
+  lines.push(`**Browsers tested:** Chromium (Desktop)  `);
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // Executive Summary
+  lines.push(`## Executive Summary`);
+  lines.push(``);
+  lines.push(`| Metric | Count |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Tests run | ${totalTests} |`);
+  lines.push(`| Tests passed | ${passed} |`);
+  lines.push(`| Tests failed | ${failed} |`);
+  lines.push(`| Tests skipped | ${skipped} |`);
+  lines.push(`| Unique axe rule violations | ${violations.length} |`);
+  lines.push(`| Critical impact | ${criticalCount} |`);
+  lines.push(`| Serious impact | ${seriousCount} |`);
+  lines.push(`| Moderate impact | ${moderateCount} |`);
+  lines.push(`| Minor impact | ${minorCount} |`);
+  lines.push(``);
+
+  if (criticalCount > 0 || seriousCount > 0) {
+    lines.push(
+      `> ⚠️  **${criticalCount + seriousCount} critical/serious violations require remediation before launch.**`
+    );
+  } else {
+    lines.push(`> ✅  No critical or serious violations found.`);
+  }
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // Automated Scan Findings
+  lines.push(`## Automated Scan Findings (axe-core)`);
+  lines.push(``);
+  if (violations.length === 0) {
+    lines.push(`No axe-core violations detected across all scanned pages.`);
+  } else {
+    lines.push(`| Rule ID | Impact | Description | Pages Affected | Occurrences |`);
+    lines.push(`|---------|--------|-------------|----------------|-------------|`);
+    for (const v of violations) {
+      const pages = v.pages.join(", ");
+      lines.push(`| \`${v.id}\` | ${v.impact} | ${v.description} | ${pages} | ${v.occurrences} |`);
+    }
+  }
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // Pre-identified Findings
+  lines.push(`## Pre-Identified Findings`);
+  lines.push(``);
+  lines.push(`These issues were identified via code analysis and validated by automated tests.`);
+  lines.push(``);
+  lines.push(`| ID | Location | Issue | Test Result |`);
+  lines.push(`|----|----------|-------|-------------|`);
+
+  const preIdentified = [
+    {
+      id: "A01",
+      location: "`app/(app)/layout.tsx`",
+      issue: "No `<main>`, `<header>`, or `<footer>` landmarks — bare `<div>` wrapper",
+    },
+    { id: "A02", location: "All pages", issue: "No skip-to-content link" },
+    {
+      id: "A03",
+      location: "`prediction-form.tsx:84-104`",
+      issue: 'Score `<Input type="number">` have no `<label>` or `aria-label`',
+    },
+    {
+      id: "A04",
+      location: "Rankings page",
+      issue: "Div-based layout instead of semantic `<table>`",
+    },
+    {
+      id: "A05",
+      location: "AppNav (mobile) + UserNav trigger",
+      issue: "Avatar/hamburger trigger button lacks accessible name",
+    },
+    {
+      id: "A06",
+      location: "`login/page.tsx:132`",
+      issue: 'Error `<div>` has no `role="alert"` — not announced to screen readers',
+    },
+    {
+      id: "A07",
+      location: "`mobile-nav.tsx`",
+      issue: "After close, focus doesn't return to hamburger trigger",
+    },
+    {
+      id: "A08",
+      location: "Profile page",
+      issue: "Decorative icons (Fingerprint, etc.) may not be `aria-hidden`",
+    },
+    {
+      id: "A09",
+      location: "`globals.css`",
+      issue: "No `prefers-reduced-motion` handling for `animate-*` CSS animations",
+    },
+    {
+      id: "A10",
+      location: "Dark mode (all pages)",
+      issue: "Potential color contrast issues (`--primary` blue on dark blue surfaces)",
+    },
+  ];
+
+  for (const finding of preIdentified) {
+    const testMatch = keyboardFindings.find((k) =>
+      k.test.toLowerCase().includes(finding.id.toLowerCase())
+    );
+    const status = testMatch ? `❌ Confirmed (test failed)` : `See test results`;
+    lines.push(`| **${finding.id}** | ${finding.location} | ${finding.issue} | ${status} |`);
+  }
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // Keyboard Navigation Findings
+  lines.push(`## Keyboard Navigation Findings`);
+  lines.push(``);
+  if (keyboardFindings.length === 0) {
+    lines.push(`No keyboard navigation failures detected.`);
+  } else {
+    lines.push(`| Test | Status | Detail |`);
+    lines.push(`|------|--------|--------|`);
+    for (const kf of keyboardFindings) {
+      lines.push(`| ${kf.test} | ${kf.status} | ${kf.detail.replace(/\n/g, " ").slice(0, 150)} |`);
+    }
+  }
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+
+  // Per-Page Summary
+  lines.push(`## Per-Page Summary`);
+  lines.push(``);
+  if (pageMap.size === 0) {
+    lines.push(`No per-page data available.`);
+  } else {
+    lines.push(`| Page | Violations | Has Critical |`);
+    lines.push(`|------|------------|--------------|`);
+    for (const [page, data] of [...pageMap.entries()].sort()) {
+      lines.push(`| \`${page}\` | ${data.violations} | ${data.hasCritical ? "❌ Yes" : "✅ No"} |`);
+    }
+  }
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+  lines.push(`## Recommended Remediation Priority`);
+  lines.push(``);
+  lines.push(`1. **Critical (immediate)**: Fix all \`critical\`-impact axe violations`);
+  lines.push(
+    `2. **High**: A01 — Add \`<main>\`, \`<header>\`, \`<nav>\` landmarks to \`app/(app)/layout.tsx\``
+  );
+  lines.push(`3. **High**: A02 — Add a skip-to-content link before the nav`);
+  lines.push(`4. **High**: A03 — Add \`aria-label\` to score inputs in \`prediction-form.tsx\``);
+  lines.push(`5. **Medium**: A06 — Add \`role="alert"\` to login error div`);
+  lines.push(`6. **Medium**: A07 — Return focus to hamburger trigger after mobile nav close`);
+  lines.push(`7. **Medium**: A04 — Use semantic \`<table>\` for the rankings layout`);
+  lines.push(`8. **Low**: A05 — Add \`aria-label\` to avatar/hamburger buttons`);
+  lines.push(`9. **Low**: A08 — Add \`aria-hidden="true"\` to decorative icons`);
+  lines.push(`10. **Low**: A09 — Add \`prefers-reduced-motion\` CSS query for animations`);
+  lines.push(`11. **Low**: A10 — Audit dark mode color contrast values`);
+  lines.push(``);
+  lines.push(`---`);
+  lines.push(``);
+  lines.push(`*Generated by \`npm run audit:a11y:summary\`*`);
+
+  fs.writeFileSync(OUTPUT_PATH, lines.join("\n"), "utf-8");
+  console.log(`✅  audit-report.md written to ${OUTPUT_PATH}`);
+  console.log(
+    `   ${violations.length} violation types found (${criticalCount} critical, ${seriousCount} serious, ${moderateCount} moderate, ${minorCount} minor)`
+  );
+}
+
+main();

--- a/__tests__/accessibility/shared/navigation.spec.ts
+++ b/__tests__/accessibility/shared/navigation.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+import { runAxe } from "../helpers/axe";
+import { collectFocusOrder } from "../helpers/keyboard";
+
+const PAGE_URL = "/tournaments";
+
+// ── Desktop navigation (default viewport: 1280×720) ──────────────────────────
+
+test("desktop: axe no violations on AppNav", async ({ page }, testInfo) => {
+  await page.goto(PAGE_URL);
+  // Scope scan to the nav element
+  const results = await runAxe(page, testInfo);
+  expect.soft(results.violations).toHaveLength(0);
+});
+
+test("desktop: Tab order in AppNav is logo → language → nav links → user nav trigger", async ({
+  page,
+}) => {
+  await page.goto(PAGE_URL);
+  const order = await collectFocusOrder(page, 20);
+  // First focusable item should be a link (logo)
+  expect.soft(order[0]?.tag).toBe("a");
+  // At least one button (UserNav trigger or LanguageSwitcher) should be in order
+  const buttons = order.filter((o) => o.tag === "button");
+  expect.soft(buttons.length).toBeGreaterThan(0);
+});
+
+test("desktop: UserNav dropdown opens with Enter and closes with Escape", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // Focus the UserNav trigger (avatar button)
+  const userNavTrigger = page
+    .getByRole("button", { name: /user menu|account|profile|avatar/i })
+    .or(page.locator("[data-testid='user-nav-trigger']"))
+    .first();
+
+  // Try to find it by tabbing to the last button in the nav
+  const trigger = page.locator("nav").getByRole("button").last();
+  await trigger.focus();
+  await page.keyboard.press("Enter");
+
+  const dropdown = page.getByRole("menu").first();
+  await expect.soft(dropdown).toBeVisible({ timeout: 3_000 });
+
+  // ArrowDown navigates within menu
+  await page.keyboard.press("ArrowDown");
+  const focusedItem = page.locator(":focus");
+  const role = await focusedItem.getAttribute("role");
+  expect.soft(role).toMatch(/menuitem|option/);
+
+  // Escape closes and returns focus to trigger
+  await page.keyboard.press("Escape");
+  await expect.soft(dropdown).toBeHidden({ timeout: 2_000 });
+});
+
+test("finding A05: desktop UserNav trigger has accessible name", async ({ page }) => {
+  await page.goto(PAGE_URL);
+  // The avatar button must have an accessible name
+  const avatarButtons = page.locator("nav").getByRole("button");
+  const count = await avatarButtons.count();
+  let foundAccessibleButton = false;
+  for (let i = 0; i < count; i++) {
+    const btn = avatarButtons.nth(i);
+    const ariaLabel = await btn.getAttribute("aria-label");
+    const text = await btn.innerText().catch(() => "");
+    const ariaLabelledBy = await btn.getAttribute("aria-labelledby");
+    if (ariaLabel || text.trim() || ariaLabelledBy) {
+      foundAccessibleButton = true;
+      break;
+    }
+  }
+  expect.soft(foundAccessibleButton).toBe(true);
+});
+
+// ── Mobile navigation (375px viewport) ────────────────────────────────────────
+
+test.describe("mobile nav (375px)", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("axe: no violations on mobile nav", async ({ page }, testInfo) => {
+    await page.goto(PAGE_URL);
+    const results = await runAxe(page, testInfo);
+    expect.soft(results.violations).toHaveLength(0);
+  });
+
+  test("keyboard: hamburger button has aria-label", async ({ page }) => {
+    await page.goto(PAGE_URL);
+    const hamburger = page.getByRole("button", { name: /toggle menu|open menu/i }).first();
+    const isVisible = await hamburger.isVisible().catch(() => false);
+    if (!isVisible) return; // Mobile menu not visible at this viewport
+    const label = await hamburger.getAttribute("aria-label");
+    expect.soft(label).toBeTruthy(); // Finding A05 (mobile)
+  });
+
+  test("keyboard: Tab opens mobile nav → links reachable → Escape closes", async ({ page }) => {
+    await page.goto(PAGE_URL);
+    const hamburger = page.getByRole("button", { name: /toggle menu|open menu/i }).first();
+    const isVisible = await hamburger.isVisible().catch(() => false);
+    if (!isVisible) return;
+
+    await hamburger.click();
+    // Mobile nav panel should open
+    const navPanel = page.getByRole("navigation").or(page.locator("[data-mobile-nav]")).last();
+    // Tab through links
+    await page.keyboard.press("Tab");
+    const firstLink = page.locator(":focus");
+    const tag = await firstLink.evaluate((el) => el.tagName.toLowerCase());
+    expect.soft(tag).toBe("a");
+
+    // Escape should close the nav
+    await page.keyboard.press("Escape");
+  });
+
+  test("finding A07: focus does NOT return to hamburger after mobile nav closes", async ({
+    page,
+  }) => {
+    await page.goto(PAGE_URL);
+    const hamburger = page.getByRole("button", { name: /toggle menu|open menu/i }).first();
+    const isVisible = await hamburger.isVisible().catch(() => false);
+    if (!isVisible) return;
+
+    await hamburger.click();
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300); // Wait for animation
+
+    // Check if focus is on the hamburger button after close
+    const focusedElement = page.locator(":focus");
+    const isFocusedOnHamburger = await hamburger
+      .evaluate((el) => el === document.activeElement)
+      .catch(() => false);
+
+    // Expected to FAIL — Finding A07: focus doesn't return to trigger
+    expect.soft(isFocusedOnHamburger).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,9 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/eslintrc": "^3.3.3",
+        "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -39,6 +41,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.19",
+        "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "^15.1.5",
         "jsdom": "^28.1.0",
@@ -48,6 +51,7 @@
         "supabase": "^2.0.0",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
+        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.0.18"
       }
@@ -133,6 +137,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2611,6 +2628,22 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6146,6 +6179,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -9202,6 +9248,52 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/po-parser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
@@ -10862,6 +10954,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "supabase:status": "npx supabase status",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "audit:a11y:setup": "playwright test --project=setup",
+    "audit:a11y": "playwright test --project=audit",
+    "audit:a11y:report": "playwright show-report playwright-report",
+    "audit:a11y:summary": "tsx __tests__/accessibility/reports/generate-summary.ts",
+    "audit:a11y:full": "playwright test && tsx __tests__/accessibility/reports/generate-summary.ts"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -50,7 +55,9 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/eslintrc": "^3.3.3",
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -60,6 +67,7 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.19",
+    "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "^15.1.5",
     "jsdom": "^28.1.0",
@@ -69,6 +77,7 @@
     "supabase": "^2.0.0",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.0.18"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+
+// Load .env.local so TEST_USER_EMAIL / TEST_ADMIN_EMAIL / TEST_PASSWORD
+// are available to auth.setup.ts without being committed to source control.
+config({ path: ".env.local" });
+
+export default defineConfig({
+  testDir: "./__tests__/accessibility",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  reporter: [
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    ["json", { outputFile: "test-results/results.json" }],
+    ["list"],
+  ],
+  use: {
+    baseURL: "http://localhost:3000",
+    actionTimeout: 5000,
+    navigationTimeout: 15000,
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: "**/auth.setup.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "audit",
+      testMatch: "**/accessibility/**/*.spec.ts",
+      dependencies: ["setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "__tests__/.auth/user.json",
+      },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
  @axe-core/playwright. Adds 68 WCAG 2.1 AA tests across 13 spec files
  covering auth pages, app pages, admin pages, and navigation — including
  targeted assertions for 10 pre-identified findings (missing landmarks,
  unlabelled score inputs, missing skip link, focus management gaps, and
  reduced-motion handling). Includes a report generator that produces
  audit-report.md from test results. Auth credentials are loaded from
  .env.local (gitignored) via dotenv — never hardcoded.