### PR TITLE
fix(a11y): add landmark elements, skip-to-content link, and role=alert

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -38,8 +38,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   return (
     <div className="min-h-screen bg-background">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:border focus:rounded-md focus:text-sm"
+      >
+        Skip to content
+      </a>
       <AppNav user={userProfile} />
-      {children}
+      <main id="main-content">{children}</main>
     </div>
   );
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -129,7 +129,7 @@ export default function LoginPage() {
                 required
               />
             </div>
-            {error && <div className="text-sm text-destructive">{error}</div>}
+            {error && <div role="alert" aria-live="assertive" className="text-sm text-destructive">{error}</div>}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t("loggingIn") : t("loginButton")}
             </Button>


### PR DESCRIPTION
Resolves #50

## Changes

This PR addresses three WCAG 2.1 Level AA accessibility issues identified in the audit:

### A01 — Missing landmark elements (WCAG 1.3.6)
- **File:** `app/(app)/layout.tsx`
- Wrapped `{children}` in a `<main>` element so screen readers can navigate by landmarks.

### A02 — No skip-to-content link (WCAG 2.4.1)
- **File:** `app/(app)/layout.tsx`
- Added a visually-hidden skip link as the first focusable element in the layout. It becomes visible on focus and jumps to `#main-content`.

### A06 — Login error missing `role="alert"` (WCAG 4.1.3)
- **File:** `app/(auth)/login/page.tsx`
- Added `role="alert"` and `aria-live="assertive"` to the error message `<div>` so screen readers announce it when it appears dynamically.

## Testing
These are semantic HTML and ARIA attribute additions — no visual changes. Can be verified by:
1. Tabbing through the app to confirm the skip link appears
2. Using a screen reader to confirm landmarks are announced
3. Triggering a login error to confirm the alert is announced