### PR TITLE
a11y: fix dark mode color contrast for WCAG AA compliance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,38 +88,38 @@
     --popover: 202 100% 16%;
     --popover-foreground: 0 0% 98%;
 
-    --primary: 200 100% 49%; /* #00A6FB - Vivid Cerulean */
+    --primary: 200 100% 55%; /* Brightened for 5:1+ contrast on card */
     --primary-foreground: 200 75% 8%;
 
     --secondary: 199 100% 29%; /* #006494 - Sea Blue */
     --secondary-foreground: 0 0% 98%;
 
     --muted: 199 100% 29%;
-    --muted-foreground: 200 100% 80%;
+    --muted-foreground: 200 100% 82%;
 
-    --accent: 202 95% 41%; /* #0582CA - Honolulu Blue */
+    --accent: 202 95% 55%; /* Brightened for 5:1+ contrast on card */
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 100% 39.6% 30.6%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
 
     --border: 199 100% 29%;
     --input: 199 100% 29%;
-    --ring: 200 100% 49%; /* Primary color */
+    --ring: 200 100% 55%; /* Match primary */
 
     /* Chart colors for dark mode */
-    --chart-1: 200 100% 49%; /* #00A6FB */
-    --chart-2: 202 95% 41%; /* #0582CA */
-    --chart-3: 199 100% 29%; /* #006494 */
-    --chart-4: 202 100% 16%; /* #003554 */
-    --chart-5: 200 75% 8%; /* #051923 */
+    --chart-1: 200 100% 55%;
+    --chart-2: 202 95% 50%;
+    --chart-3: 199 100% 42%;
+    --chart-4: 202 100% 32%;
+    --chart-5: 200 75% 22%;
 
     /* Semantic status colors - Dark Mode */
     --success: 142 71% 45%;
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
-    --info: 200 100% 49%;
+    --info: 200 100% 55%;
     --info-foreground: 200 75% 8%;
 
     /* Achievement / podium colors */


### PR DESCRIPTION
## Summary
- Brighten `--primary` and `--accent` in dark mode (lightness 49%/41% → 55%) to achieve 5:1+ contrast ratio on card backgrounds, up from ~4.4:1 and ~3.2:1 respectively
- Fix malformed `--destructive` HSL value (was `100% 39.6% 30.6%` — missing hue) → `0 84% 60%`
- Update `--ring`, `--info`, `--muted-foreground`, and chart colors to match the adjusted palette

Closes #49

## Contrast ratios (verified)

| Color | Surface | Before | After |
|---|---|---|---|
| `--primary` | on card (`#003554`) | 4.4:1 ✗ | 5.5:1 ✓ |
| `--primary` | on background (`#051923`) | 6.8:1 ✓ | 7.6:1 ✓ |
| `--accent` | on card | 3.2:1 ✗ | 5.0:1 ✓ |
| `--accent` | on background | 4.4:1 ✗ | 6.9:1 ✓ |
| `--destructive` | on background | N/A (malformed) | 4.7:1 ✓ |

## Test plan
- [ ] Verify dark mode visually — colors remain within the Blue Lagoon palette family
- [ ] Run `npm test` — all 112 unit tests pass
- [ ] Run `npm run build` — production build succeeds
- [ ] Run accessibility audit on affected pages (login, signup, forgot-password, profile, tournaments, admin pages) to confirm axe contrast checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)