### PR TITLE
security: add input validation to score, prediction, and team endpoints

### DIFF
--- a/app/api/admin/matches/[matchId]/score/__tests__/route.test.ts
+++ b/app/api/admin/matches/[matchId]/score/__tests__/route.test.ts
@@ -93,6 +93,60 @@ describe("POST /api/admin/matches/[matchId]/score", () => {
     predictionsResult.error = null;
   });
 
+  // ── Validation tests ──────────────────────────────────────────────────────
+
+  it("returns 400 for non-integer home_score", async () => {
+    const response = await POST(makeRequest({ home_score: 1.5, away_score: 0 }), matchParams);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Scores must be integers");
+  });
+
+  it("returns 400 for negative scores", async () => {
+    const response = await POST(makeRequest({ home_score: -1, away_score: 0 }), matchParams);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for scores exceeding max", async () => {
+    const response = await POST(makeRequest({ home_score: 0, away_score: 100 }), matchParams);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for string scores", async () => {
+    const response = await POST(makeRequest({ home_score: "two", away_score: 0 }), matchParams);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for null scores", async () => {
+    const response = await POST(makeRequest({ home_score: null, away_score: 0 }), matchParams);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for invalid status string", async () => {
+    const response = await POST(
+      makeRequest({ home_score: 1, away_score: 0, status: "invalid_status" }),
+      matchParams
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Invalid status");
+  });
+
+  it("accepts all valid status values", async () => {
+    matchesResult.data = { multiplier: 1, tournament_id: "t-1", status: "scheduled" };
+    predictionsResult.data = [];
+
+    for (const validStatus of ["scheduled", "in_progress", "completed", "cancelled"]) {
+      const response = await POST(
+        makeRequest({ home_score: 1, away_score: 0, status: validStatus }),
+        matchParams
+      );
+      expect(response.status).toBe(200);
+    }
+  });
+
+  // ── Auth & error tests ──────────────────────────────────────────────────────
+
   it("returns 403 when admin check fails", async () => {
     mockCheckAdminPermission.mockResolvedValue(
       new Response(JSON.stringify({ error: "Admin access required" }), { status: 403 })

--- a/app/api/admin/matches/[matchId]/score/route.ts
+++ b/app/api/admin/matches/[matchId]/score/route.ts
@@ -3,6 +3,9 @@ import { checkAdminPermission } from "@/lib/middleware/admin-check";
 import { NextRequest, NextResponse } from "next/server";
 import { calculatePoints } from "@/lib/utils/scoring";
 import { getCurrentUTC } from "@/lib/utils/date";
+import type { MatchStatus } from "@/types/database";
+
+const VALID_STATUSES: MatchStatus[] = ["scheduled", "in_progress", "completed", "cancelled"];
 
 export async function POST(
   request: NextRequest,
@@ -16,6 +19,29 @@ export async function POST(
     const { matchId } = await params;
     const body = await request.json();
     const { home_score, away_score, status } = body;
+
+    if (
+      typeof home_score !== "number" ||
+      !Number.isInteger(home_score) ||
+      home_score < 0 ||
+      home_score > 99 ||
+      typeof away_score !== "number" ||
+      !Number.isInteger(away_score) ||
+      away_score < 0 ||
+      away_score > 99
+    ) {
+      return NextResponse.json(
+        { error: "Scores must be integers between 0 and 99" },
+        { status: 400 }
+      );
+    }
+
+    if (status && !VALID_STATUSES.includes(status)) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}` },
+        { status: 400 }
+      );
+    }
 
     // Get match details to retrieve multiplier and current status
     const { data: matchData, error: matchFetchError } = await supabase

--- a/app/api/admin/matches/[matchId]/score/route.ts
+++ b/app/api/admin/matches/[matchId]/score/route.ts
@@ -36,7 +36,7 @@ export async function POST(
       );
     }
 
-    if (status && !VALID_STATUSES.includes(status)) {
+    if (status !== undefined && status !== null && !VALID_STATUSES.includes(status)) {
       return NextResponse.json(
         { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}` },
         { status: 400 }

--- a/app/api/admin/teams/__tests__/route.test.ts
+++ b/app/api/admin/teams/__tests__/route.test.ts
@@ -78,6 +78,59 @@ describe("POST /api/admin/teams", () => {
     teamsResult.error = null;
   });
 
+  // ── Validation tests ──────────────────────────────────────────────────────
+
+  it("returns 400 when name is missing", async () => {
+    const response = await POST(makeRequest({ short_name: "BRA", country_code: "BR" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("name");
+  });
+
+  it("returns 400 when name is empty string", async () => {
+    const response = await POST(
+      makeRequest({ name: "  ", short_name: "BRA", country_code: "BR" })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when name exceeds 100 characters", async () => {
+    const response = await POST(
+      makeRequest({ name: "A".repeat(101), short_name: "BRA", country_code: "BR" })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when short_name is missing", async () => {
+    const response = await POST(makeRequest({ name: "Brazil", country_code: "BR" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("short_name");
+  });
+
+  it("returns 400 when short_name exceeds 10 characters", async () => {
+    const response = await POST(
+      makeRequest({ name: "Brazil", short_name: "TOOLONGNAME", country_code: "BR" })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when country_code is missing", async () => {
+    const response = await POST(makeRequest({ name: "Brazil", short_name: "BRA" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("country_code");
+  });
+
+  it("returns 400 when country_code is not 2 characters", async () => {
+    const response = await POST(
+      makeRequest({ name: "Brazil", short_name: "BRA", country_code: "BRA" })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  // ── Auth & error tests ──────────────────────────────────────────────────────
+
   it("returns 403 when admin check fails", async () => {
     mockCheckAdminPermission.mockResolvedValue(
       new Response(JSON.stringify({ error: "Admin access required" }), { status: 403 })

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -12,32 +12,25 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { name, short_name, country_code, logo_url } = body;
 
-    if (!name || typeof name !== "string" || name.trim().length === 0 || name.length > 100) {
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    if (!trimmedName || trimmedName.length > 100) {
       return NextResponse.json(
         { error: "name is required and must be a string of 1-100 characters" },
         { status: 400 }
       );
     }
 
-    if (
-      !short_name ||
-      typeof short_name !== "string" ||
-      short_name.trim().length === 0 ||
-      short_name.length > 10
-    ) {
+    const trimmedShortName = typeof short_name === "string" ? short_name.trim() : "";
+    if (!trimmedShortName || trimmedShortName.length > 10) {
       return NextResponse.json(
         { error: "short_name is required and must be a string of 1-10 characters" },
         { status: 400 }
       );
     }
 
-    if (
-      !country_code ||
-      typeof country_code !== "string" ||
-      country_code.length !== 2
-    ) {
+    if (!country_code || typeof country_code !== "string" || !/^[A-Za-z]{2}$/.test(country_code)) {
       return NextResponse.json(
-        { error: "country_code is required and must be a 2-character ISO code" },
+        { error: "country_code must be a 2-letter ISO code (e.g. BR, US)" },
         { status: 400 }
       );
     }
@@ -45,8 +38,8 @@ export async function POST(request: NextRequest) {
     const { data, error } = await supabase
       .from("teams")
       .insert({
-        name,
-        short_name,
+        name: trimmedName,
+        short_name: trimmedShortName,
         country_code,
         logo_url,
       })

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -12,6 +12,36 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { name, short_name, country_code, logo_url } = body;
 
+    if (!name || typeof name !== "string" || name.trim().length === 0 || name.length > 100) {
+      return NextResponse.json(
+        { error: "name is required and must be a string of 1-100 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (
+      !short_name ||
+      typeof short_name !== "string" ||
+      short_name.trim().length === 0 ||
+      short_name.length > 10
+    ) {
+      return NextResponse.json(
+        { error: "short_name is required and must be a string of 1-10 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (
+      !country_code ||
+      typeof country_code !== "string" ||
+      country_code.length !== 2
+    ) {
+      return NextResponse.json(
+        { error: "country_code is required and must be a 2-character ISO code" },
+        { status: 400 }
+      );
+    }
+
     const { data, error } = await supabase
       .from("teams")
       .insert({

--- a/app/api/predictions/__tests__/route.test.ts
+++ b/app/api/predictions/__tests__/route.test.ts
@@ -1,0 +1,299 @@
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockAuthUser } from "@/__tests__/helpers/supabase-mock";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const mockCheckUserActive = vi.hoisted(() => vi.fn());
+
+const { mockSupabase, mockAuth, matchesQb, matchesResult, participantsQb, participantsResult, predictionsQb, predictionsResult } =
+  vi.hoisted(() => {
+    function makeQb() {
+      const result = { data: null as unknown, error: null as unknown };
+      const qb: Record<string, ReturnType<typeof vi.fn>> = {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        eq: vi.fn(),
+        neq: vi.fn(),
+        in: vi.fn(),
+        single: vi.fn(),
+        maybeSingle: vi.fn(),
+        limit: vi.fn(),
+        order: vi.fn(),
+      };
+      for (const key of Object.keys(qb)) {
+        if (key === "single" || key === "maybeSingle")
+          qb[key].mockImplementation(() => Promise.resolve(result));
+        else qb[key].mockReturnValue(qb);
+      }
+      Object.defineProperty(qb, "then", {
+        get: () => (resolve: (v: unknown) => void) => resolve(result),
+        configurable: true,
+      });
+      return { qb, result };
+    }
+
+    const { qb: matchesQb, result: matchesResult } = makeQb();
+    const { qb: participantsQb, result: participantsResult } = makeQb();
+    const { qb: predictionsQb, result: predictionsResult } = makeQb();
+
+    const mockAuth = {
+      getUser: vi.fn(),
+      signUp: vi.fn(),
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      exchangeCodeForSession: vi.fn(),
+    };
+
+    return {
+      mockSupabase: { auth: mockAuth, from: vi.fn() },
+      mockAuth,
+      matchesQb,
+      matchesResult,
+      participantsQb,
+      participantsResult,
+      predictionsQb,
+      predictionsResult,
+    };
+  });
+
+vi.mock("@/lib/middleware/user-status-check", () => ({
+  checkUserActive: mockCheckUserActive,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabase),
+}));
+
+vi.mock("@/lib/utils/date", () => ({
+  getCurrentUTC: vi.fn(() => "2026-02-21T00:00:00.000Z"),
+}));
+
+// Import after mocking
+import { POST } from "../route";
+
+const USER_ID = "user-123";
+
+// ── POST /api/predictions ─────────────────────────────────────────────────────
+
+describe("POST /api/predictions", () => {
+  const makeRequest = (body: object) =>
+    new NextRequest("http://localhost/api/predictions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const validBody = {
+    match_id: "match-1",
+    predicted_home_score: 2,
+    predicted_away_score: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckUserActive.mockResolvedValue(null);
+    mockAuth.getUser.mockResolvedValue({
+      data: { user: createMockAuthUser({ id: USER_ID }) },
+      error: null,
+    });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "matches") return matchesQb;
+      if (table === "tournament_participants") return participantsQb;
+      return predictionsQb;
+    });
+    matchesResult.data = null;
+    matchesResult.error = null;
+    participantsResult.data = null;
+    participantsResult.error = null;
+    predictionsResult.data = null;
+    predictionsResult.error = null;
+  });
+
+  // ── Validation tests ──────────────────────────────────────────────────────
+
+  it("returns 400 when match_id is missing", async () => {
+    const response = await POST(
+      makeRequest({ predicted_home_score: 1, predicted_away_score: 0 })
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("match_id");
+  });
+
+  it("returns 400 when match_id is not a string", async () => {
+    const response = await POST(
+      makeRequest({ match_id: 123, predicted_home_score: 1, predicted_away_score: 0 })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for non-integer predicted scores", async () => {
+    const response = await POST(
+      makeRequest({ match_id: "m-1", predicted_home_score: 1.5, predicted_away_score: 0 })
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Scores must be integers");
+  });
+
+  it("returns 400 for negative predicted scores", async () => {
+    const response = await POST(
+      makeRequest({ match_id: "m-1", predicted_home_score: -1, predicted_away_score: 0 })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for scores exceeding max", async () => {
+    const response = await POST(
+      makeRequest({ match_id: "m-1", predicted_home_score: 0, predicted_away_score: 100 })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for string scores", async () => {
+    const response = await POST(
+      makeRequest({ match_id: "m-1", predicted_home_score: "two", predicted_away_score: 0 })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  // ── Auth tests ──────────────────────────────────────────────────────────────
+
+  it("returns 403 when user is deactivated", async () => {
+    mockCheckUserActive.mockResolvedValue(
+      new Response(JSON.stringify({ error: "Account deactivated" }), { status: 403 })
+    );
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockAuth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(401);
+  });
+
+  // ── Business logic tests ────────────────────────────────────────────────────
+
+  it("returns 404 when match is not found", async () => {
+    matchesResult.data = null;
+    matchesResult.error = { message: "Not found" };
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when user is not a tournament participant", async () => {
+    matchesResult.data = { tournament_id: "t-1" };
+    participantsResult.data = null;
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("participant");
+  });
+
+  it("creates a new prediction when none exists", async () => {
+    matchesResult.data = { tournament_id: "t-1" };
+    participantsResult.data = { user_id: USER_ID };
+    // First predictions query (check existing) returns null
+    // Second predictions query (insert) returns created data
+    const createdPrediction = {
+      id: "pred-new",
+      user_id: USER_ID,
+      match_id: "match-1",
+      predicted_home_score: 2,
+      predicted_away_score: 1,
+    };
+
+    // For the existing-check query, single() returns null data
+    // For the insert query, single() returns the new prediction
+    let predictionsCallCount = 0;
+    predictionsQb.single.mockImplementation(() => {
+      predictionsCallCount++;
+      if (predictionsCallCount === 1) {
+        // Check existing — not found
+        return Promise.resolve({ data: null, error: null });
+      }
+      // Insert result
+      return Promise.resolve({ data: createdPrediction, error: null });
+    });
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe("pred-new");
+    expect(predictionsQb.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: USER_ID,
+        match_id: "match-1",
+        predicted_home_score: 2,
+        predicted_away_score: 1,
+      })
+    );
+  });
+
+  it("updates an existing prediction", async () => {
+    matchesResult.data = { tournament_id: "t-1" };
+    participantsResult.data = { user_id: USER_ID };
+
+    const updatedPrediction = {
+      id: "pred-existing",
+      user_id: USER_ID,
+      match_id: "match-1",
+      predicted_home_score: 2,
+      predicted_away_score: 1,
+    };
+
+    let predictionsCallCount = 0;
+    predictionsQb.single.mockImplementation(() => {
+      predictionsCallCount++;
+      if (predictionsCallCount === 1) {
+        // Check existing — found
+        return Promise.resolve({ data: { id: "pred-existing" }, error: null });
+      }
+      // Update result
+      return Promise.resolve({ data: updatedPrediction, error: null });
+    });
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe("pred-existing");
+    expect(predictionsQb.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        predicted_home_score: 2,
+        predicted_away_score: 1,
+      })
+    );
+  });
+
+  it("returns 500 on DB error during insert", async () => {
+    matchesResult.data = { tournament_id: "t-1" };
+    participantsResult.data = { user_id: USER_ID };
+
+    let predictionsCallCount = 0;
+    predictionsQb.single.mockImplementation(() => {
+      predictionsCallCount++;
+      if (predictionsCallCount === 1) {
+        return Promise.resolve({ data: null, error: null });
+      }
+      return Promise.resolve({ data: null, error: { message: "Insert failed" } });
+    });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toContain("Failed to save prediction");
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/api/predictions/route.ts
+++ b/app/api/predictions/route.ts
@@ -21,6 +21,26 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { match_id, predicted_home_score, predicted_away_score } = body;
 
+    if (!match_id || typeof match_id !== "string") {
+      return NextResponse.json({ error: "match_id is required" }, { status: 400 });
+    }
+
+    if (
+      typeof predicted_home_score !== "number" ||
+      !Number.isInteger(predicted_home_score) ||
+      predicted_home_score < 0 ||
+      predicted_home_score > 99 ||
+      typeof predicted_away_score !== "number" ||
+      !Number.isInteger(predicted_away_score) ||
+      predicted_away_score < 0 ||
+      predicted_away_score > 99
+    ) {
+      return NextResponse.json(
+        { error: "Scores must be integers between 0 and 99" },
+        { status: 400 }
+      );
+    }
+
     // Get the match to find the tournament_id
     const { data: match, error: matchError } = await supabase
       .from("matches")


### PR DESCRIPTION
## Summary

Closes #37

- **Score endpoint** (`/api/admin/matches/[matchId]/score`): validates `home_score`/`away_score` are integers 0-99 and `status` is a valid `MatchStatus` enum value
- **Predictions endpoint** (`/api/predictions`): validates `match_id` is a non-empty string and predicted scores are integers 0-99
- **Teams endpoint** (`/api/admin/teams`): validates `name` (1-100 chars), `short_name` (1-10 chars), and `country_code` (exactly 2 chars) are present and correctly sized

All invalid inputs return 400 with descriptive error messages.

## Test plan

- [x] 7 new validation tests for score endpoint (non-integer, negative, max exceeded, string, null, invalid status, valid statuses)
- [x] 7 new validation tests for teams endpoint (missing/empty/too-long name, missing/too-long short_name, missing/wrong-length country_code)
- [x] 13 new tests for predictions endpoint (6 validation + 2 auth + 5 business logic)
- [x] All 178 tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)