### PR TITLE
a11y: add accessible names to all SelectTrigger comboboxes (closes #48)

### DIFF
--- a/components/layout/language-switcher.tsx
+++ b/components/layout/language-switcher.tsx
@@ -28,7 +28,7 @@ export function LanguageSwitcher() {
 
   return (
     <div className="flex items-center gap-2">
-      <Globe className="h-4 w-4 text-muted-foreground" />
+      <Globe className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
       <Select value={locale} onValueChange={handleLanguageChange} disabled={isChanging}>
         <SelectTrigger className="w-[140px]" aria-label={t("selectLanguage")}>
           <SelectValue placeholder={t("selectLanguage")} />

--- a/components/layout/language-switcher.tsx
+++ b/components/layout/language-switcher.tsx
@@ -30,7 +30,7 @@ export function LanguageSwitcher() {
     <div className="flex items-center gap-2">
       <Globe className="h-4 w-4 text-muted-foreground" />
       <Select value={locale} onValueChange={handleLanguageChange} disabled={isChanging}>
-        <SelectTrigger className="w-[140px]">
+        <SelectTrigger className="w-[140px]" aria-label={t("selectLanguage")}>
           <SelectValue placeholder={t("selectLanguage")} />
         </SelectTrigger>
         <SelectContent>

--- a/components/matches/management/match-create-form.tsx
+++ b/components/matches/management/match-create-form.tsx
@@ -88,7 +88,7 @@ export function MatchCreateForm({ tournamentId, teams }: MatchCreateFormProps) {
                 onValueChange={(value) => setFormData({ ...formData, home_team_id: value })}
                 required
               >
-                <SelectTrigger>
+                <SelectTrigger id="home_team_id">
                   <SelectValue placeholder={t("selectHomeTeam")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -108,7 +108,7 @@ export function MatchCreateForm({ tournamentId, teams }: MatchCreateFormProps) {
                 onValueChange={(value) => setFormData({ ...formData, away_team_id: value })}
                 required
               >
-                <SelectTrigger>
+                <SelectTrigger id="away_team_id">
                   <SelectValue placeholder={t("selectAwayTeam")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -154,7 +154,7 @@ export function MatchCreateForm({ tournamentId, teams }: MatchCreateFormProps) {
                   setFormData({ ...formData, status: value as MatchStatus })
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="status">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/components/matches/management/match-edit-form.tsx
+++ b/components/matches/management/match-edit-form.tsx
@@ -138,7 +138,7 @@ export function MatchEditForm({ match, teams }: MatchEditFormProps) {
                 onValueChange={(value) => setFormData({ ...formData, home_team_id: value })}
                 required
               >
-                <SelectTrigger>
+                <SelectTrigger id="home_team_id">
                   <SelectValue placeholder={t("selectHomeTeam")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -158,7 +158,7 @@ export function MatchEditForm({ match, teams }: MatchEditFormProps) {
                 onValueChange={(value) => setFormData({ ...formData, away_team_id: value })}
                 required
               >
-                <SelectTrigger>
+                <SelectTrigger id="away_team_id">
                   <SelectValue placeholder={t("selectAwayTeam")} />
                 </SelectTrigger>
                 <SelectContent>
@@ -204,7 +204,7 @@ export function MatchEditForm({ match, teams }: MatchEditFormProps) {
                   setFormData({ ...formData, status: value as MatchStatus })
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="status">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/components/matches/management/match-management-list.tsx
+++ b/components/matches/management/match-management-list.tsx
@@ -96,7 +96,10 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
       <div className="space-y-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Search
+              className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
             <Input
               placeholder={t("management.searchTeams")}
               value={searchQuery}
@@ -155,8 +158,9 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
                   size="sm"
                   className="h-auto p-0 ml-1 hover:text-destructive"
                   onClick={() => setSearchQuery("")}
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </Button>
               </Badge>
             )}
@@ -168,8 +172,9 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
                   size="sm"
                   className="h-auto p-0 ml-1 hover:text-destructive"
                   onClick={() => setStatusFilter("all")}
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </Button>
               </Badge>
             )}
@@ -181,8 +186,9 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
                   size="sm"
                   className="h-auto p-0 ml-1 hover:text-destructive"
                   onClick={() => setRoundFilter("all")}
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </Button>
               </Badge>
             )}

--- a/components/matches/management/match-management-list.tsx
+++ b/components/matches/management/match-management-list.tsx
@@ -106,7 +106,10 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
           </div>
 
           <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-full sm:w-[180px]">
+            <SelectTrigger
+              className="w-full sm:w-[180px]"
+              aria-label={t("management.filterByStatus")}
+            >
               <SelectValue placeholder={t("management.filterByStatus")} />
             </SelectTrigger>
             <SelectContent>
@@ -120,7 +123,10 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
 
           {rounds.length > 0 && (
             <Select value={roundFilter} onValueChange={setRoundFilter}>
-              <SelectTrigger className="w-full sm:w-[180px]">
+              <SelectTrigger
+                className="w-full sm:w-[180px]"
+                aria-label={t("management.filterByRound")}
+              >
                 <SelectValue placeholder={t("management.filterByRound")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/teams/management/team-management-list.tsx
+++ b/components/teams/management/team-management-list.tsx
@@ -90,7 +90,10 @@ export function TeamManagementList({
 
           {/* Country Filter */}
           <Select value={selectedCountry} onValueChange={setSelectedCountry}>
-            <SelectTrigger className="w-full sm:w-[180px]">
+            <SelectTrigger
+              className="w-full sm:w-[180px]"
+              aria-label={tCommon("filters.filterBy", { field: tCommon("filters.country") })}
+            >
               <SelectValue
                 placeholder={tCommon("filters.filterBy", { field: tCommon("filters.country") })}
               />
@@ -107,7 +110,10 @@ export function TeamManagementList({
 
           {/* Tournament Filter */}
           <Select value={selectedTournament} onValueChange={setSelectedTournament}>
-            <SelectTrigger className="w-full sm:w-[220px]">
+            <SelectTrigger
+              className="w-full sm:w-[220px]"
+              aria-label={tCommon("filters.filterBy", { field: tCommon("filters.tournament") })}
+            >
               <SelectValue
                 placeholder={tCommon("filters.filterBy", { field: tCommon("filters.tournament") })}
               />

--- a/components/teams/management/team-management-list.tsx
+++ b/components/teams/management/team-management-list.tsx
@@ -79,7 +79,10 @@ export function TeamManagementList({
         <div className="flex flex-col sm:flex-row gap-4">
           {/* Search */}
           <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+            <Search
+              className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4"
+              aria-hidden="true"
+            />
             <Input
               placeholder={t("searchPlaceholder")}
               value={searchQuery}
@@ -141,8 +144,9 @@ export function TeamManagementList({
                 <button
                   onClick={() => setSelectedCountry("all")}
                   className="ml-1 hover:text-destructive"
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </button>
               </Badge>
             )}
@@ -153,8 +157,9 @@ export function TeamManagementList({
                 <button
                   onClick={() => setSelectedTournament("all")}
                   className="ml-1 hover:text-destructive"
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </button>
               </Badge>
             )}

--- a/components/tournaments/management/tournament-create-form.tsx
+++ b/components/tournaments/management/tournament-create-form.tsx
@@ -131,7 +131,7 @@ export function TournamentCreateForm() {
                 setFormData({ ...formData, status: value })
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="status">
                 <SelectValue placeholder={t("selectStatus")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/tournaments/management/tournament-detail-view.tsx
+++ b/components/tournaments/management/tournament-detail-view.tsx
@@ -112,9 +112,12 @@ export function TournamentDetailView({
     setRemovingTeamId(teamId);
 
     try {
-      const response = await fetch(`/api/admin/tournaments/${tournament.id}/teams?teamId=${teamId}`, {
-        method: "DELETE",
-      });
+      const response = await fetch(
+        `/api/admin/tournaments/${tournament.id}/teams?teamId=${teamId}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (!response.ok) {
         const data = await response.json();
@@ -268,7 +271,7 @@ export function TournamentDetailView({
           {/* Add Team */}
           <div className="flex gap-2">
             <Select value={selectedTeamId} onValueChange={setSelectedTeamId}>
-              <SelectTrigger className="flex-1">
+              <SelectTrigger className="flex-1" aria-label={t("detail.selectTeamToAdd")}>
                 <SelectValue placeholder={t("detail.selectTeamToAdd")} />
               </SelectTrigger>
               <SelectContent>
@@ -339,7 +342,7 @@ export function TournamentDetailView({
           {/* Add Participant */}
           <div className="flex gap-2">
             <Select value={selectedUserId} onValueChange={setSelectedUserId}>
-              <SelectTrigger className="flex-1">
+              <SelectTrigger className="flex-1" aria-label={t("detail.selectUserToAdd")}>
                 <SelectValue placeholder={t("detail.selectUserToAdd")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/tournaments/management/tournament-detail-view.tsx
+++ b/components/tournaments/management/tournament-detail-view.tsx
@@ -192,8 +192,8 @@ export function TournamentDetailView({
       <div className="flex flex-col sm:flex-row justify-between items-start gap-4">
         <div className="flex items-start gap-4">
           <Link href="/tournaments/manage">
-            <Button variant="ghost" size="icon">
-              <ArrowLeft className="h-4 w-4" />
+            <Button variant="ghost" size="icon" aria-label={tCommon("actions.back")}>
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
             </Button>
           </Link>
           <div>
@@ -288,11 +288,15 @@ export function TournamentDetailView({
                 )}
               </SelectContent>
             </Select>
-            <Button onClick={handleAddTeam} disabled={!selectedTeamId || isAddingTeam}>
+            <Button
+              onClick={handleAddTeam}
+              disabled={!selectedTeamId || isAddingTeam}
+              aria-label={tCommon("actions.add")}
+            >
               {isAddingTeam ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               )}
             </Button>
           </div>
@@ -315,12 +319,12 @@ export function TournamentDetailView({
                     size="icon"
                     onClick={() => handleRemoveTeam(team.id)}
                     disabled={removingTeamId === team.id}
-                    title="Remove from tournament"
+                    aria-label={t("detail.removeFromTournament")}
                   >
                     {removingTeamId === team.id ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                     ) : (
-                      <X className="h-4 w-4" />
+                      <X className="h-4 w-4" aria-hidden="true" />
                     )}
                   </Button>
                 </div>
@@ -362,11 +366,12 @@ export function TournamentDetailView({
             <Button
               onClick={handleAddParticipant}
               disabled={!selectedUserId || isAddingParticipant}
+              aria-label={tCommon("actions.add")}
             >
               {isAddingParticipant ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               )}
             </Button>
           </div>

--- a/components/tournaments/management/tournament-edit-form.tsx
+++ b/components/tournaments/management/tournament-edit-form.tsx
@@ -170,7 +170,7 @@ export function TournamentEditForm({ tournament }: TournamentEditFormProps) {
                 setFormData({ ...formData, status: value })
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="status">
                 <SelectValue placeholder={tForm("selectStatus")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/tournaments/management/tournament-management-list.tsx
+++ b/components/tournaments/management/tournament-management-list.tsx
@@ -60,7 +60,10 @@ export function TournamentManagementList({
       <div className="flex flex-col gap-4">
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+            <Search
+              className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4"
+              aria-hidden="true"
+            />
             <Input
               placeholder={t("searchPlaceholder")}
               value={searchQuery}
@@ -93,8 +96,9 @@ export function TournamentManagementList({
                 <button
                   onClick={() => setSelectedStatus("all")}
                   className="ml-1 hover:text-destructive"
+                  aria-label={tCommon("actions.clearFilters")}
                 >
-                  <X className="h-3 w-3" />
+                  <X className="h-3 w-3" aria-hidden="true" />
                 </button>
               </Badge>
             )}

--- a/components/tournaments/management/tournament-management-list.tsx
+++ b/components/tournaments/management/tournament-management-list.tsx
@@ -70,7 +70,7 @@ export function TournamentManagementList({
           </div>
 
           <Select value={selectedStatus} onValueChange={setSelectedStatus}>
-            <SelectTrigger className="w-full sm:w-[180px]">
+            <SelectTrigger className="w-full sm:w-[180px]" aria-label={t("filterByStatus")}>
               <SelectValue placeholder={t("filterByStatus")} />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
Add aria-label or id/htmlFor linking to every Radix SelectTrigger that lacked an accessible name, fixing the WCAG 4.1.2 button-name violation across admin, app, and shared navigation pages.