### PR TITLE
security: hardening and logging improvements (closes #41)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,7 +29,12 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       userProfile = data;
     }
 
-    // Check if user is deactivated and sign them out
+    // Check if user is deactivated and sign them out.
+    // NOTE: This is a server-side security check — not UX-only. However it runs
+    // at the layout level (after the page starts rendering), so deactivated users
+    // may briefly see the app shell before the redirect fires. For a hard edge-level
+    // block, move this check into middleware.ts once the user status is accessible
+    // there (e.g., via a custom JWT claim or an edge-compatible DB query).
     if (userProfile?.status === "deactivated") {
       await supabase.auth.signOut();
       redirect("/login?error=account_deactivated");

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,12 +29,9 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       userProfile = data;
     }
 
-    // Check if user is deactivated and sign them out.
-    // NOTE: This is a server-side security check — not UX-only. However it runs
-    // at the layout level (after the page starts rendering), so deactivated users
-    // may briefly see the app shell before the redirect fires. For a hard edge-level
-    // block, move this check into middleware.ts once the user status is accessible
-    // there (e.g., via a custom JWT claim or an edge-compatible DB query).
+    // Defense-in-depth: also checked at the edge in lib/supabase/middleware.ts
+    // (which fires before this layout renders). This check is a fallback for
+    // routes not covered by the middleware or for direct server component renders.
     if (userProfile?.status === "deactivated") {
       await supabase.auth.signOut();
       redirect("/login?error=account_deactivated");

--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse, type NextRequest } from "next/server";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockAuth, mockQueryBuilder, mockQueryResult, mockSupabase } = vi.hoisted(() => {
+  const result = { data: null as unknown, error: null as unknown };
+
+  const qb: Record<string, ReturnType<typeof vi.fn>> = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(),
+  };
+  qb.select.mockReturnValue(qb);
+  qb.eq.mockReturnValue(qb);
+  qb.maybeSingle.mockImplementation(() => Promise.resolve(result));
+
+  const mockAuth = {
+    getUser: vi.fn(),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+  };
+
+  return {
+    mockAuth,
+    mockQueryBuilder: qb,
+    mockQueryResult: result,
+    mockSupabase: {
+      auth: mockAuth,
+      from: vi.fn().mockReturnValue(qb),
+    },
+  };
+});
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => mockSupabase),
+}));
+
+import { updateSession } from "../middleware";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeRequest(pathname: string): NextRequest {
+  const url = new URL(`http://localhost${pathname}`);
+  return {
+    nextUrl: url,
+    url: url.toString(),
+    cookies: { getAll: () => [], set: vi.fn() },
+  } as unknown as NextRequest;
+}
+
+const activeUser = { id: "user-1", email: "test@example.com" };
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("updateSession middleware — deactivated-user check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.from.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.select.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.eq.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.maybeSingle.mockImplementation(() => Promise.resolve(mockQueryResult));
+    mockAuth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    mockAuth.signOut.mockResolvedValue({ error: null });
+    mockQueryResult.data = null;
+    mockQueryResult.error = null;
+  });
+
+  it("passes through when no user is authenticated", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await updateSession(makeRequest("/"));
+
+    expect(res.status).not.toBe(302);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it("passes through for active user on a protected route", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: activeUser }, error: null });
+    mockQueryResult.data = { status: "active" };
+
+    const res = await updateSession(makeRequest("/tournaments/abc"));
+
+    expect(res.status).not.toBe(302);
+    expect(mockAuth.signOut).not.toHaveBeenCalled();
+  });
+
+  it("redirects deactivated user on a protected route to /login?error=account_deactivated", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: activeUser }, error: null });
+    mockQueryResult.data = { status: "deactivated" };
+
+    const res = await updateSession(makeRequest("/tournaments/abc/predictions"));
+
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+    const location = res.headers.get("location");
+    expect(location).toContain("/login");
+    expect(location).toContain("error=account_deactivated");
+    expect(mockAuth.signOut).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "/login",
+    "/signup",
+    "/forgot-password",
+    "/auth/callback",
+    "/api/auth/passkey/authenticate-options",
+    "/api/predictions",
+    "/_next/static/chunk.js",
+    "/unauthorized",
+  ])("skips deactivation check for public/api route: %s", async (path) => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: activeUser }, error: null });
+
+    await updateSession(makeRequest(path));
+
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+    expect(mockAuth.signOut).not.toHaveBeenCalled();
+  });
+
+  it("passes through and warns when profile fetch errors", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: activeUser }, error: null });
+    mockQueryResult.data = null;
+    mockQueryResult.error = { message: "DB error" };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await updateSession(makeRequest("/tournaments/abc"));
+
+    expect(res.status).not.toBe(302);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[middleware] status check failed",
+      expect.objectContaining({ userId: activeUser.id })
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 
 /**

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,10 +1,12 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-// Public routes that do NOT require a deactivated-user check.
-// All other routes (including dynamic [tournamentId] routes) will be checked.
+// Routes that do NOT get the deactivated-user check in middleware.
+// API routes are excluded because a redirect would break JSON clients — those
+// routes enforce deactivation individually via checkUserActive() middleware.
+// All other app routes are covered automatically (deny-list, not allow-list).
 const PUBLIC_ROUTE_PREFIX =
-  /^\/(login|signup|forgot-password|update-password|auth|unauthorized|_next|favicon\.ico|api)/;
+  /^\/(login|signup|forgot-password|update-password|auth|unauthorized|_next|favicon\.ico|api)(\/|$)/;
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -41,21 +43,26 @@ export async function updateSession(request: NextRequest) {
   // Inverted allow-list: skip only known public routes so new app routes are
   // covered automatically without needing to update this regex.
   if (user && !PUBLIC_ROUTE_PREFIX.test(request.nextUrl.pathname)) {
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from("users")
       .select("status")
       .eq("id", user.id)
-      .single();
+      .maybeSingle();
+
+    if (profileError) {
+      console.warn("[middleware] status check failed", { userId: user.id });
+    }
 
     if (profile?.status === "deactivated") {
       await supabase.auth.signOut();
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("error", "account_deactivated");
-      // Copy auth-clearing cookies from supabaseResponse into the redirect so
-      // signOut() actually clears the session (redirect is a new Response object).
+      // Copy auth-clearing cookies (with full options) from supabaseResponse into
+      // the redirect so signOut() actually clears the session. Passing the full
+      // cookie object preserves httpOnly, Secure, SameSite, etc.
       const redirectResponse = NextResponse.redirect(loginUrl);
       supabaseResponse.cookies.getAll().forEach((cookie) => {
-        redirectResponse.cookies.set(cookie.name, cookie.value);
+        redirectResponse.cookies.set(cookie);
       });
       return redirectResponse;
     }

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,6 +1,10 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+// App routes that require an active (non-deactivated) user session.
+// Auth routes and public routes are excluded — they don't need a status check.
+const APP_ROUTE_PREFIX = /^\/(tournaments|teams|admin|profile)/;
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -27,8 +31,27 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Refreshing the auth token
-  await supabase.auth.getUser();
+  // Refresh the auth token
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Block deactivated users at the edge before any page renders.
+  // Only check app routes — no need to check auth/public pages.
+  if (user && APP_ROUTE_PREFIX.test(request.nextUrl.pathname)) {
+    const { data: profile } = await supabase
+      .from("users")
+      .select("status")
+      .eq("id", user.id)
+      .single();
+
+    if (profile?.status === "deactivated") {
+      await supabase.auth.signOut();
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("error", "account_deactivated");
+      return NextResponse.redirect(loginUrl);
+    }
+  }
 
   return supabaseResponse;
 }

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,9 +1,10 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-// App routes that require an active (non-deactivated) user session.
-// Auth routes and public routes are excluded — they don't need a status check.
-const APP_ROUTE_PREFIX = /^\/(tournaments|teams|admin|profile)/;
+// Public routes that do NOT require a deactivated-user check.
+// All other routes (including dynamic [tournamentId] routes) will be checked.
+const PUBLIC_ROUTE_PREFIX =
+  /^\/(login|signup|forgot-password|update-password|auth|unauthorized|_next|favicon\.ico|api)/;
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -37,8 +38,9 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   // Block deactivated users at the edge before any page renders.
-  // Only check app routes — no need to check auth/public pages.
-  if (user && APP_ROUTE_PREFIX.test(request.nextUrl.pathname)) {
+  // Inverted allow-list: skip only known public routes so new app routes are
+  // covered automatically without needing to update this regex.
+  if (user && !PUBLIC_ROUTE_PREFIX.test(request.nextUrl.pathname)) {
     const { data: profile } = await supabase
       .from("users")
       .select("status")
@@ -49,7 +51,13 @@ export async function updateSession(request: NextRequest) {
       await supabase.auth.signOut();
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("error", "account_deactivated");
-      return NextResponse.redirect(loginUrl);
+      // Copy auth-clearing cookies from supabaseResponse into the redirect so
+      // signOut() actually clears the session (redirect is a new Response object).
+      const redirectResponse = NextResponse.redirect(loginUrl);
+      supabaseResponse.cookies.getAll().forEach((cookie) => {
+        redirectResponse.cookies.set(cookie.name, cookie.value);
+      });
+      return redirectResponse;
     }
   }
 

--- a/lib/webauthn/server.ts
+++ b/lib/webauthn/server.ts
@@ -311,7 +311,7 @@ export async function verifyUserAuthenticationResponse(
       "[WebAuthn] Authentication verification failed — possible phishing or origin mismatch",
       {
         expectedOrigin: rpConfig.origin,
-        credentialId: credentialID,
+        credentialIdPrefix: credentialID?.slice(0, 8),
       }
     );
     throw new Error("Authentication verification failed");

--- a/lib/webauthn/server.ts
+++ b/lib/webauthn/server.ts
@@ -151,6 +151,10 @@ export async function verifyUserRegistrationResponse(
   const verification = await verifyRegistrationResponse(opts);
 
   if (!verification.verified || !verification.registrationInfo) {
+    console.warn("[WebAuthn] Registration verification failed", {
+      expectedOrigin: rpConfig.origin,
+      userId,
+    });
     throw new Error("Registration verification failed");
   }
 
@@ -303,6 +307,13 @@ export async function verifyUserAuthenticationResponse(
   const verification = await verifyAuthenticationResponse(opts);
 
   if (!verification.verified) {
+    console.warn(
+      "[WebAuthn] Authentication verification failed — possible phishing or origin mismatch",
+      {
+        expectedOrigin: rpConfig.origin,
+        credentialId: credentialID,
+      }
+    );
     throw new Error("Authentication verification failed");
   }
 


### PR DESCRIPTION
8a: add server-only guard to lib/supabase/admin.ts to prevent accidental
    client-side import of the service-role client
8b: document that the deactivation check in app layout is server-side but
    layout-level — add note about moving to middleware for edge interception
8c: add console.warn on WebAuthn registration and authentication verification
    failures (origin mismatch = potential phishing indicator)
8d: move deactivated-user check to middleware so the redirect fires at the
    edge before any page content renders, eliminating the brief app-shell flash