### PR TITLE
a11y: fix keyboard navigation across auth forms, nav, and dialogs (cl…

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -40,9 +40,6 @@ export default function ForgotPasswordPage() {
   if (submitted) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary p-4 relative">
-        <div className="absolute top-4 right-4">
-          <LanguageSwitcher />
-        </div>
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="text-2xl">{t("successTitle")}</CardTitle>
@@ -57,15 +54,15 @@ export default function ForgotPasswordPage() {
             </Link>
           </CardContent>
         </Card>
+        <div className="absolute top-4 right-4">
+          <LanguageSwitcher />
+        </div>
       </div>
     );
   }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary p-4 relative">
-      <div className="absolute top-4 right-4">
-        <LanguageSwitcher />
-      </div>
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">{t("title")}</CardTitle>
@@ -86,7 +83,11 @@ export default function ForgotPasswordPage() {
                 required
               />
             </div>
-            {error && <div className="text-sm text-destructive">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t("sending") : t("sendResetLink")}
             </Button>
@@ -98,6 +99,9 @@ export default function ForgotPasswordPage() {
           </div>
         </CardContent>
       </Card>
+      <div className="absolute top-4 right-4">
+        <LanguageSwitcher />
+      </div>
     </div>
   );
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -60,12 +60,6 @@ export default function LoginPage() {
       <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--primary)/0.08)_0%,transparent_70%)]" />
 
-      <div className="absolute top-4 right-4 z-10">
-        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
-          <LanguageSwitcher />
-        </div>
-      </div>
-
       <Card className="w-full max-w-md relative animate-scale-in">
         <CardHeader>
           <CardTitle className="font-display text-3xl uppercase tracking-tight">
@@ -129,7 +123,11 @@ export default function LoginPage() {
                 required
               />
             </div>
-            {error && <div role="alert" aria-live="assertive" className="text-sm text-destructive">{error}</div>}
+            {error && (
+              <div role="alert" aria-live="assertive" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t("loggingIn") : t("loginButton")}
             </Button>
@@ -142,6 +140,13 @@ export default function LoginPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Language switcher — placed after main card so form fields receive focus first */}
+      <div className="absolute top-4 right-4 z-10">
+        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
+          <LanguageSwitcher />
+        </div>
+      </div>
 
       {/* Migration Prompt Modal */}
       <PasskeyMigrationPrompt

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -124,7 +124,7 @@ export default function LoginPage() {
               />
             </div>
             {error && (
-              <div role="alert" aria-live="assertive" className="text-sm text-destructive">
+              <div role="alert" className="text-sm text-destructive">
                 {error}
               </div>
             )}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -54,12 +54,6 @@ export default function SignupPage() {
       <div className="absolute inset-0 bg-gradient-to-b from-background via-background to-secondary" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--primary)/0.08)_0%,transparent_70%)]" />
 
-      <div className="absolute top-4 right-4 z-10">
-        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
-          <LanguageSwitcher />
-        </div>
-      </div>
-
       <Card className="w-full max-w-md relative animate-scale-in">
         <CardHeader>
           <CardTitle className="font-display text-3xl uppercase tracking-tight">
@@ -108,7 +102,11 @@ export default function SignupPage() {
                 minLength={6}
               />
             </div>
-            {error && <div className="text-sm text-destructive">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t("creatingAccount") : t("signUpButton")}
             </Button>
@@ -121,6 +119,13 @@ export default function SignupPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Language switcher — placed after main card so form fields receive focus first */}
+      <div className="absolute top-4 right-4 z-10">
+        <div className="backdrop-blur-sm bg-background/50 rounded-lg p-1">
+          <LanguageSwitcher />
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/auth/passkey/passkey-login-button.tsx
+++ b/components/auth/passkey/passkey-login-button.tsx
@@ -87,7 +87,7 @@ export function PasskeyLoginButton({
         onClick={handleAuthenticate}
         disabled={isLoading}
         aria-disabled={!email || isLoading}
-        className="w-full"
+        className="w-full aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
       >
         {isLoading ? (
           <>
@@ -103,7 +103,10 @@ export function PasskeyLoginButton({
       </Button>
 
       {error && (
-        <div className="bg-destructive/15 text-destructive px-4 py-3 rounded-md text-sm">
+        <div
+          role="alert"
+          className="bg-destructive/15 text-destructive px-4 py-3 rounded-md text-sm"
+        >
           {error}
         </div>
       )}

--- a/components/auth/passkey/passkey-login-button.tsx
+++ b/components/auth/passkey/passkey-login-button.tsx
@@ -91,12 +91,12 @@ export function PasskeyLoginButton({
       >
         {isLoading ? (
           <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
             {tCommon("status.authenticating")}
           </>
         ) : (
           <>
-            <Fingerprint className="mr-2 h-4 w-4" />
+            <Fingerprint className="mr-2 h-4 w-4" aria-hidden="true" />
             {t("signInWithPasskey")}
           </>
         )}

--- a/components/auth/passkey/passkey-login-button.tsx
+++ b/components/auth/passkey/passkey-login-button.tsx
@@ -83,7 +83,12 @@ export function PasskeyLoginButton({
 
   return (
     <div className={`space-y-3 ${className || ""}`}>
-      <Button onClick={handleAuthenticate} disabled={isLoading || !email} className="w-full">
+      <Button
+        onClick={handleAuthenticate}
+        disabled={isLoading}
+        aria-disabled={!email || isLoading}
+        className="w-full"
+      >
         {isLoading ? (
           <>
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -25,11 +25,14 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
     hamburgerRef.current?.focus();
   };
 
-  // Close on Escape key
+  // Close on Escape key — logic inlined to avoid stale-closure lint warning
   useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeMenu();
+      if (e.key === "Escape") {
+        setIsOpen(false);
+        hamburgerRef.current?.focus();
+      }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
@@ -87,7 +90,7 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
           </div>
 
           {/* Menu Items */}
-          <nav className="flex-1 overflow-y-auto" aria-label={t("navigation.mobileMenu")}>
+          <nav className="flex-1 overflow-y-auto">
             <div className="flex flex-col p-4 space-y-1">
               <div className="mb-3">
                 <LanguageSwitcher />

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -16,14 +16,44 @@ interface MobileNavProps {
 export function MobileNav({ user, onSignOut }: MobileNavProps) {
   const t = useTranslations("common");
   const [isOpen, setIsOpen] = useState(false);
+  const hamburgerRef = useRef<HTMLButtonElement>(null);
+  const firstLinkRef = useRef<HTMLAnchorElement>(null);
 
-  const closeMenu = () => setIsOpen(false);
+  const openMenu = () => setIsOpen(true);
+  const closeMenu = () => {
+    setIsOpen(false);
+    hamburgerRef.current?.focus();
+  };
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeMenu();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  // Move focus to first nav link when menu opens
+  useEffect(() => {
+    if (isOpen) {
+      firstLinkRef.current?.focus();
+    }
+  }, [isOpen]);
 
   return (
     <>
       {/* Hamburger Button */}
-      <button onClick={() => setIsOpen(!isOpen)} className="md:hidden p-2" aria-label="Toggle menu">
-        {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+      <button
+        ref={hamburgerRef}
+        onClick={openMenu}
+        className="md:hidden p-2"
+        aria-label={t("navigation.openMenu")}
+        aria-expanded={isOpen}
+        aria-controls="mobile-nav-menu"
+      >
+        <Menu className="h-6 w-6" aria-hidden="true" />
       </button>
 
       {/* Mobile Menu Overlay */}
@@ -31,34 +61,41 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
         <div
           className="fixed inset-0 bg-background/60 backdrop-blur-sm z-40 md:hidden"
           onClick={closeMenu}
+          aria-hidden="true"
         />
       )}
 
       {/* Mobile Menu Sidebar */}
       <div
+        id="mobile-nav-menu"
+        role="dialog"
+        aria-label={t("navigation.mobileMenu")}
+        aria-modal="true"
         className={`fixed top-0 right-0 h-full w-72 bg-background/95 backdrop-blur-xl border-l z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
+        aria-hidden={!isOpen}
+        inert={!isOpen ? true : undefined}
       >
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b">
             <span className="font-display font-bold uppercase tracking-tight">{t("appName")}</span>
-            <button onClick={closeMenu} aria-label="Close menu">
-              <X className="h-5 w-5" />
+            <button onClick={closeMenu} aria-label={t("navigation.closeMenu")}>
+              <X className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
 
           {/* Menu Items */}
-          <nav className="flex-1 overflow-y-auto">
+          <nav className="flex-1 overflow-y-auto" aria-label={t("navigation.mobileMenu")}>
             <div className="flex flex-col p-4 space-y-1">
               <div className="mb-3">
                 <LanguageSwitcher />
               </div>
 
-              <Link href="/tournaments" onClick={closeMenu}>
+              <Link href="/tournaments" onClick={closeMenu} ref={firstLinkRef}>
                 <Button variant="ghost" className="w-full justify-start gap-3">
-                  <Trophy className="h-4 w-4" />
+                  <Trophy className="h-4 w-4" aria-hidden="true" />
                   {t("navigation.tournaments")}
                 </Button>
               </Link>
@@ -67,25 +104,25 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
                 <>
                   <div className="pt-3 pb-1 px-3">
                     <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      <Shield className="h-3 w-3" />
+                      <Shield className="h-3 w-3" aria-hidden="true" />
                       {t("navigation.admin")}
                     </div>
                   </div>
                   <Link href="/tournaments/manage" onClick={closeMenu}>
                     <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <Settings className="h-4 w-4" />
+                      <Settings className="h-4 w-4" aria-hidden="true" />
                       {t("navigation.manageTournaments")}
                     </Button>
                   </Link>
                   <Link href="/teams" onClick={closeMenu}>
                     <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <Users className="h-4 w-4" />
+                      <Users className="h-4 w-4" aria-hidden="true" />
                       {t("navigation.manageTeams")}
                     </Button>
                   </Link>
                   <Link href="/admin/users" onClick={closeMenu}>
                     <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <UserCircle className="h-4 w-4" />
+                      <UserCircle className="h-4 w-4" aria-hidden="true" />
                       {t("navigation.userManagement")}
                     </Button>
                   </Link>
@@ -97,7 +134,7 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
                   <div className="border-t my-3" />
                   <Link href="/profile" onClick={closeMenu}>
                     <Button variant="ghost" className="w-full justify-start gap-3">
-                      <UserCircle className="h-4 w-4" />
+                      <UserCircle className="h-4 w-4" aria-hidden="true" />
                       {t("navigation.account")}
                     </Button>
                   </Link>
@@ -109,7 +146,7 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
                       onSignOut();
                     }}
                   >
-                    <LogOut className="h-4 w-4" />
+                    <LogOut className="h-4 w-4" aria-hidden="true" />
                     {t("navigation.signOut")}
                   </Button>
                 </>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -18,25 +18,13 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
   const [isOpen, setIsOpen] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const openMenu = () => setIsOpen(true);
   const closeMenu = () => {
     setIsOpen(false);
     hamburgerRef.current?.focus();
   };
-
-  // Close on Escape key — logic inlined to avoid stale-closure lint warning
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setIsOpen(false);
-        hamburgerRef.current?.focus();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
 
   // Move focus to first nav link when menu opens
   useEffect(() => {
@@ -45,14 +33,56 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
     }
   }, [isOpen]);
 
+  // Scroll lock, focus trap, and Escape handler — active only while menu is open
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const mainContent = document.getElementById("main-content");
+    if (mainContent) mainContent.setAttribute("inert", "");
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+        hamburgerRef.current?.focus();
+        return;
+      }
+
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      mainContent?.removeAttribute("inert");
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
   return (
     <>
       {/* Hamburger Button */}
       <button
         ref={hamburgerRef}
-        onClick={openMenu}
+        onClick={isOpen ? closeMenu : openMenu}
         className="md:hidden p-2"
-        aria-label={t("navigation.openMenu")}
+        aria-label={isOpen ? t("navigation.closeMenu") : t("navigation.openMenu")}
         aria-expanded={isOpen}
         aria-controls="mobile-nav-menu"
       >
@@ -71,6 +101,7 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
       {/* Mobile Menu Sidebar */}
       <div
         id="mobile-nav-menu"
+        ref={dialogRef}
         role="dialog"
         aria-label={t("navigation.mobileMenu")}
         aria-modal="true"

--- a/components/profile/user-nav.tsx
+++ b/components/profile/user-nav.tsx
@@ -44,12 +44,18 @@ export function UserNav({ user }: UserNavProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-10 gap-2 px-2">
+        <Button
+          variant="ghost"
+          className="relative h-10 gap-2 px-2"
+          aria-label={t("navigation.accountMenu", { name: displayName })}
+        >
           <Avatar className="h-8 w-8">
             <AvatarImage src={user.avatar_url ?? undefined} alt={displayName} />
-            <AvatarFallback>{initials}</AvatarFallback>
+            <AvatarFallback aria-hidden="true">{initials}</AvatarFallback>
           </Avatar>
-          <span className="hidden md:inline-block font-medium text-sm">{displayName}</span>
+          <span className="hidden md:inline-block font-medium text-sm" aria-hidden="true">
+            {displayName}
+          </span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>

--- a/messages/en.json
+++ b/messages/en.json
@@ -740,6 +740,8 @@
     "goBack": "Go back",
     "toggleTheme": "Toggle theme",
     "openMenu": "Open menu",
-    "closeMenu": "Close menu"
+    "closeMenu": "Close menu",
+    "mobileMenu": "Mobile navigation",
+    "accountMenu": "{name}'s account menu"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -740,6 +740,8 @@
     "goBack": "Volver",
     "toggleTheme": "Cambiar tema",
     "openMenu": "Abrir menú",
-    "closeMenu": "Cerrar menú"
+    "closeMenu": "Cerrar menú",
+    "mobileMenu": "Navegación móvil",
+    "accountMenu": "Menú de cuenta de {name}"
   }
 }


### PR DESCRIPTION
…oses #51)

- Mobile nav: add Escape key handler, inert when closed, focus first link on open, aria-modal/role=dialog, return focus to hamburger on close
- UserNav: add aria-label to account menu trigger (fixes mobile where display name is hidden)
- Auth pages (login/signup/forgot-password): move LanguageSwitcher after main card in DOM so form fields receive Tab focus first
- Passkey button: use aria-disabled instead of disabled to keep it in tab order while still signalling unavailability to AT
- Signup/forgot-password: add role="alert" to error messages
- i18n: add mobileMenu and accountMenu translation keys (EN + ES)