### PR TITLE
feat: display full team names instead of short names

### DIFF
--- a/components/teams/team-badge.tsx
+++ b/components/teams/team-badge.tsx
@@ -36,7 +36,7 @@ export function TeamBadge({ team, size = "md", showName = true, className }: Tea
             size === "lg" && "text-lg"
           )}
         >
-          {team.short_name}
+          {team.name}
         </span>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Match cards and team labels now show the full team name (e.g. "Argentina") instead of the abbreviated short name (e.g. "ARG").
- Implemented as a one-line change in the shared `TeamBadge` component (`components/teams/team-badge.tsx`), so the change propagates everywhere a team name is rendered: tournament dashboard, predictions view (form + result cards), matches list, match detail, rankings, team selector, and admin previews.
- The short code is retained inside the small logo-fallback circle, where the full name would not fit. The image `alt` already used the full name.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] Verified tournament dashboard shows full names (Brazil, Germany, France, England, Spain, Netherlands, Argentina, Mexico)
- [x] Verified predictions view shows full names on both prediction-form cards and completed-result cards
- [x] Confirmed logo-fallback circles still show short abbreviations
- [ ] Note: name labels do not truncate; a very long full name could wrap in tighter cards (none in current seed data trigger it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)