### PR TITLE
fix: UI bugs (mobile nav, predictions, team layout, admin badge) + per-participant scoring breakdown

### DIFF
--- a/app/(app)/(user)/(admin)/tournaments/manage/[tournamentId]/page.tsx
+++ b/app/(app)/(user)/(admin)/tournaments/manage/[tournamentId]/page.tsx
@@ -62,7 +62,8 @@ export default async function TournamentDetailPage({ params }: TournamentDetailP
         id,
         email,
         screen_name,
-        avatar_url
+        avatar_url,
+        is_admin
       )
     `
     )
@@ -94,7 +95,7 @@ export default async function TournamentDetailPage({ params }: TournamentDetailP
   // Fetch all users for the dropdown (admin page - will be masked in component)
   const { data: allUsers } = await supabase
     .from("users")
-    .select("id, screen_name, avatar_url, email")
+    .select("id, screen_name, avatar_url, email, is_admin")
     .order("screen_name");
 
   return (

--- a/app/(app)/(user)/[tournamentId]/predictions/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/predictions/page.tsx
@@ -145,33 +145,33 @@ export default function PredictionsPage() {
 
       {!isParticipant && (
         <div className="mb-8 p-6 bg-muted/50 border rounded-lg text-center">
-          <h3 className="text-lg font-semibold mb-2">{t("notParticipant")}</h3>
-          <p className="text-muted-foreground">{t("notParticipantMessage")}</p>
+          <h3 className="text-lg font-semibold mb-2">{t("notParticipant.title")}</h3>
+          <p className="text-muted-foreground">{t("notParticipant.message")}</p>
         </div>
       )}
 
-      <div className="space-y-12">
-        {/* Completed Matches Section */}
-        {completedWithPredictions.length > 0 && (
-          <div>
-            <div className="mb-4">
-              <h2 className="text-2xl font-bold">{t("completedMatches")}</h2>
-              <p className="text-sm text-muted-foreground">{t("completedMatchesSubtitle")}</p>
+      {isParticipant && (
+        <div className="space-y-12">
+          {/* Completed Matches Section */}
+          {completedWithPredictions.length > 0 && (
+            <div>
+              <div className="mb-4">
+                <h2 className="text-2xl font-bold">{t("completedMatches")}</h2>
+                <p className="text-sm text-muted-foreground">{t("completedMatchesSubtitle")}</p>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {completedWithPredictions.map((match) => (
+                  <PredictionResultCard
+                    key={match.id}
+                    match={match}
+                    prediction={predictions[match.id]}
+                  />
+                ))}
+              </div>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {completedWithPredictions.map((match) => (
-                <PredictionResultCard
-                  key={match.id}
-                  match={match}
-                  prediction={predictions[match.id]}
-                />
-              ))}
-            </div>
-          </div>
-        )}
+          )}
 
-        {/* Upcoming Matches Section */}
-        {isParticipant && (
+          {/* Upcoming Matches Section */}
           <div>
             <div className="mb-4">
               <h2 className="text-2xl font-bold">{t("upcomingMatches")}</h2>
@@ -194,8 +194,8 @@ export default function PredictionsPage() {
               </div>
             )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,11 @@ interface MobileNavProps {
 export function MobileNav({ user, onSignOut }: MobileNavProps) {
   const t = useTranslations("common");
   const [isOpen, setIsOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const closeMenu = () => setIsOpen(false);
 
@@ -26,98 +32,108 @@ export function MobileNav({ user, onSignOut }: MobileNavProps) {
         {isOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
       </button>
 
-      {/* Mobile Menu Overlay */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 bg-background/60 backdrop-blur-sm z-40 md:hidden"
-          onClick={closeMenu}
-        />
-      )}
+      {/* Overlay + sidebar are portaled to document.body so they escape the nav's
+          backdrop-filter containing block and sticky stacking context. */}
+      {mounted &&
+        createPortal(
+          <>
+            {/* Mobile Menu Overlay */}
+            {isOpen && (
+              <div
+                className="fixed inset-0 bg-background/60 backdrop-blur-sm z-40 md:hidden"
+                onClick={closeMenu}
+              />
+            )}
 
-      {/* Mobile Menu Sidebar */}
-      <div
-        className={`fixed top-0 right-0 h-full w-72 bg-background/95 backdrop-blur-xl border-l z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
-          isOpen ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <div className="flex flex-col h-full">
-          {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b">
-            <span className="font-display font-bold uppercase tracking-tight">{t("appName")}</span>
-            <button onClick={closeMenu} aria-label="Close menu">
-              <X className="h-5 w-5" />
-            </button>
-          </div>
+            {/* Mobile Menu Sidebar */}
+            <div
+              className={`fixed top-0 right-0 h-full w-72 bg-background/95 backdrop-blur-xl border-l z-50 transform transition-transform duration-300 ease-in-out md:hidden ${
+                isOpen ? "translate-x-0" : "translate-x-full"
+              }`}
+            >
+              <div className="flex flex-col h-full">
+                {/* Header */}
+                <div className="flex items-center justify-between p-4 border-b">
+                  <span className="font-display font-bold uppercase tracking-tight">
+                    {t("appName")}
+                  </span>
+                  <button onClick={closeMenu} aria-label="Close menu">
+                    <X className="h-5 w-5" />
+                  </button>
+                </div>
 
-          {/* Menu Items */}
-          <nav className="flex-1 overflow-y-auto">
-            <div className="flex flex-col p-4 space-y-1">
-              <div className="mb-3">
-                <LanguageSwitcher />
-              </div>
-
-              <Link href="/tournaments" onClick={closeMenu}>
-                <Button variant="ghost" className="w-full justify-start gap-3">
-                  <Trophy className="h-4 w-4" />
-                  {t("navigation.tournaments")}
-                </Button>
-              </Link>
-
-              {user?.is_admin && (
-                <>
-                  <div className="pt-3 pb-1 px-3">
-                    <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      <Shield className="h-3 w-3" />
-                      {t("navigation.admin")}
+                {/* Menu Items */}
+                <nav className="flex-1 overflow-y-auto">
+                  <div className="flex flex-col p-4 space-y-1">
+                    <div className="mb-3">
+                      <LanguageSwitcher />
                     </div>
-                  </div>
-                  <Link href="/tournaments/manage" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <Settings className="h-4 w-4" />
-                      {t("navigation.manageTournaments")}
-                    </Button>
-                  </Link>
-                  <Link href="/teams" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <Users className="h-4 w-4" />
-                      {t("navigation.manageTeams")}
-                    </Button>
-                  </Link>
-                  <Link href="/admin/users" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
-                      <UserCircle className="h-4 w-4" />
-                      {t("navigation.userManagement")}
-                    </Button>
-                  </Link>
-                </>
-              )}
 
-              {user && (
-                <>
-                  <div className="border-t my-3" />
-                  <Link href="/profile" onClick={closeMenu}>
-                    <Button variant="ghost" className="w-full justify-start gap-3">
-                      <UserCircle className="h-4 w-4" />
-                      {t("navigation.account")}
-                    </Button>
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start gap-3 text-destructive hover:text-destructive"
-                    onClick={() => {
-                      closeMenu();
-                      onSignOut();
-                    }}
-                  >
-                    <LogOut className="h-4 w-4" />
-                    {t("navigation.signOut")}
-                  </Button>
-                </>
-              )}
+                    <Link href="/tournaments" onClick={closeMenu}>
+                      <Button variant="ghost" className="w-full justify-start gap-3">
+                        <Trophy className="h-4 w-4" />
+                        {t("navigation.tournaments")}
+                      </Button>
+                    </Link>
+
+                    {user?.is_admin && (
+                      <>
+                        <div className="pt-3 pb-1 px-3">
+                          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                            <Shield className="h-3 w-3" />
+                            {t("navigation.admin")}
+                          </div>
+                        </div>
+                        <Link href="/tournaments/manage" onClick={closeMenu}>
+                          <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                            <Settings className="h-4 w-4" />
+                            {t("navigation.manageTournaments")}
+                          </Button>
+                        </Link>
+                        <Link href="/teams" onClick={closeMenu}>
+                          <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                            <Users className="h-4 w-4" />
+                            {t("navigation.manageTeams")}
+                          </Button>
+                        </Link>
+                        <Link href="/admin/users" onClick={closeMenu}>
+                          <Button variant="ghost" className="w-full justify-start gap-3 pl-8">
+                            <UserCircle className="h-4 w-4" />
+                            {t("navigation.userManagement")}
+                          </Button>
+                        </Link>
+                      </>
+                    )}
+
+                    {user && (
+                      <>
+                        <div className="border-t my-3" />
+                        <Link href="/profile" onClick={closeMenu}>
+                          <Button variant="ghost" className="w-full justify-start gap-3">
+                            <UserCircle className="h-4 w-4" />
+                            {t("navigation.account")}
+                          </Button>
+                        </Link>
+                        <Button
+                          variant="ghost"
+                          className="w-full justify-start gap-3 text-destructive hover:text-destructive"
+                          onClick={() => {
+                            closeMenu();
+                            onSignOut();
+                          }}
+                        >
+                          <LogOut className="h-4 w-4" />
+                          {t("navigation.signOut")}
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </nav>
+              </div>
             </div>
-          </nav>
-        </div>
-      </div>
+          </>,
+          document.body
+        )}
     </>
   );
 }

--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -84,7 +84,7 @@ export function MatchCard({ match }: MatchCardProps) {
               )}
 
               <div className={`flex-1 flex justify-end ${awayWins ? "font-semibold" : ""}`}>
-                <TeamBadge team={match.away_team} size="md" showName={true} />
+                <TeamBadge team={match.away_team} size="md" showName={true} reverse={true} />
               </div>
             </div>
 

--- a/components/matches/match-detail-view.tsx
+++ b/components/matches/match-detail-view.tsx
@@ -6,7 +6,7 @@ import { TeamBadge } from "@/components/teams/team-badge";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatLocalDateTime } from "@/lib/utils/date";
-import { Zap } from "lucide-react";
+import { Zap, Sparkles } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 interface PredictionWithUser extends Prediction {
@@ -82,7 +82,7 @@ export function MatchDetailView({ match, predictions, currentUserId }: MatchDeta
             )}
 
             <div className="flex-1 flex justify-center">
-              <TeamBadge team={match.away_team} size="lg" showName={true} />
+              <TeamBadge team={match.away_team} size="lg" showName={true} reverse={true} />
             </div>
           </div>
 
@@ -178,6 +178,7 @@ function PredictionRow({
 }: PredictionRowProps) {
   const t = useTranslations("matches.details");
   const tCommon = useTranslations("common");
+  const tResults = useTranslations("predictions.results");
   const getInitials = (name: string | null) => {
     if (!name) return "U";
     return name
@@ -189,62 +190,80 @@ function PredictionRow({
   };
 
   const showPrediction = isCompleted || isCancelled || isCurrentUser;
+  const showBreakdown =
+    showPrediction && isCompleted && !isCancelled && prediction.points_earned > 0;
 
   return (
     <div
-      className={`flex items-center justify-between p-3 rounded-lg ${
+      className={`p-3 rounded-lg ${
         isCurrentUser ? "bg-primary/10 border border-primary/20" : "bg-muted/50"
       }`}
     >
-      {/* User Info */}
-      <div className="flex items-center gap-3">
-        <Avatar className="h-8 w-8">
-          <AvatarImage
-            src={prediction.user.avatar_url || undefined}
-            alt={prediction.user.screen_name || "User"}
-          />
-          <AvatarFallback>{getInitials(prediction.user.screen_name)}</AvatarFallback>
-        </Avatar>
-        <div>
-          <p className="font-medium">
-            {prediction.user.screen_name || t("anonymous")}
-            {isCurrentUser && <span className="ml-2 text-xs text-primary">{t("you")}</span>}
-          </p>
+      <div className="flex items-center justify-between">
+        {/* User Info */}
+        <div className="flex items-center gap-3">
+          <Avatar className="h-8 w-8">
+            <AvatarImage
+              src={prediction.user.avatar_url || undefined}
+              alt={prediction.user.screen_name || "User"}
+            />
+            <AvatarFallback>{getInitials(prediction.user.screen_name)}</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="font-medium">
+              {prediction.user.screen_name || t("anonymous")}
+              {isCurrentUser && <span className="ml-2 text-xs text-primary">{t("you")}</span>}
+            </p>
+          </div>
+        </div>
+
+        {/* Prediction Score or Hidden */}
+        <div className="flex items-center gap-4">
+          {showPrediction ? (
+            <>
+              <div className="text-center">
+                <p className="text-lg font-bold font-display">
+                  {prediction.predicted_home_score} : {prediction.predicted_away_score}
+                </p>
+              </div>
+              {isCompleted && !isCancelled && (
+                <div className="text-center min-w-[60px]">
+                  <Badge
+                    variant={prediction.points_earned > 0 ? "default" : "outline"}
+                    className={
+                      prediction.points_earned >= 3 * match.multiplier
+                        ? "bg-success"
+                        : prediction.points_earned > 0
+                          ? "bg-info"
+                          : ""
+                    }
+                  >
+                    {prediction.points_earned} {tCommon("labels.pts")}
+                  </Badge>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="text-center">
+              <span className="text-muted-foreground italic text-sm">{t("hiddenUntilEnd")}</span>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Prediction Score or Hidden */}
-      <div className="flex items-center gap-4">
-        {showPrediction ? (
-          <>
-            <div className="text-center">
-              <p className="text-lg font-bold font-display">
-                {prediction.predicted_home_score} : {prediction.predicted_away_score}
-              </p>
-            </div>
-            {isCompleted && !isCancelled && (
-              <div className="text-center min-w-[60px]">
-                <Badge
-                  variant={prediction.points_earned > 0 ? "default" : "outline"}
-                  className={
-                    prediction.points_earned >= 3 * match.multiplier
-                      ? "bg-success"
-                      : prediction.points_earned > 0
-                        ? "bg-info"
-                        : ""
-                  }
-                >
-                  {prediction.points_earned} {tCommon("labels.pts")}
-                </Badge>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="text-center">
-            <span className="text-muted-foreground italic text-sm">{t("hiddenUntilEnd")}</span>
-          </div>
-        )}
-      </div>
+      {/* Points explanation */}
+      {showBreakdown && (
+        <div className="text-right text-xs text-muted-foreground mt-2">
+          {prediction.points_earned === 3 * match.multiplier && (
+            <span className="inline-flex items-center justify-end gap-1">
+              <Sparkles className="h-3 w-3 text-success" />
+              {tResults("exactMatch")}
+            </span>
+          )}
+          {prediction.points_earned === 2 * match.multiplier && tResults("correctDifference")}
+          {prediction.points_earned === 1 * match.multiplier && tResults("correctWinner")}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/predictions/prediction-form.tsx
+++ b/components/predictions/prediction-form.tsx
@@ -89,7 +89,7 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
                 onChange={(e) => setHomeScore(e.target.value)}
                 disabled={isLocked || isSubmitting}
                 className="w-20 text-center text-2xl font-display font-bold bg-surface-sunken"
-                placeholder="0"
+                placeholder="#"
               />
               <span className="text-muted-foreground font-bold">:</span>
               <Input
@@ -100,12 +100,12 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
                 onChange={(e) => setAwayScore(e.target.value)}
                 disabled={isLocked || isSubmitting}
                 className="w-20 text-center text-2xl font-display font-bold bg-surface-sunken"
-                placeholder="0"
+                placeholder="#"
               />
             </div>
 
             <div className="flex-1 flex justify-end">
-              <TeamBadge team={match.away_team} size="sm" showName={true} />
+              <TeamBadge team={match.away_team} size="sm" showName={true} reverse={true} />
             </div>
           </div>
         </CardContent>

--- a/components/predictions/prediction-result-card.tsx
+++ b/components/predictions/prediction-result-card.tsx
@@ -77,7 +77,7 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
             </div>
 
             <div className="flex-1 flex justify-end">
-              <TeamBadge team={match.away_team} size="sm" showName={true} />
+              <TeamBadge team={match.away_team} size="sm" showName={true} reverse={true} />
             </div>
           </div>
           <div className="text-center text-xs font-medium text-muted-foreground">

--- a/components/rankings/user-predictions-view.tsx
+++ b/components/rankings/user-predictions-view.tsx
@@ -232,7 +232,7 @@ function PredictionRow({ prediction, showDetails }: PredictionRowProps) {
           </div>
 
           <div className="flex-1 flex justify-end">
-            <TeamBadge team={match.away_team} size="sm" showName={true} />
+            <TeamBadge team={match.away_team} size="sm" showName={true} reverse={true} />
           </div>
         </div>
 

--- a/components/teams/team-badge.tsx
+++ b/components/teams/team-badge.tsx
@@ -6,6 +6,7 @@ interface TeamBadgeProps {
   team: Team;
   size?: "sm" | "md" | "lg";
   showName?: boolean;
+  reverse?: boolean;
   className?: string;
 }
 
@@ -15,9 +16,15 @@ const sizeClasses = {
   lg: "h-16 w-16",
 };
 
-export function TeamBadge({ team, size = "md", showName = true, className }: TeamBadgeProps) {
+export function TeamBadge({
+  team,
+  size = "md",
+  showName = true,
+  reverse = false,
+  className,
+}: TeamBadgeProps) {
   return (
-    <div className={cn("flex items-center gap-2", className)}>
+    <div className={cn("flex items-center gap-2", reverse && "flex-row-reverse", className)}>
       <div className={cn("relative rounded-full overflow-hidden border", sizeClasses[size])}>
         {team.logo_url ? (
           <Image src={team.logo_url} alt={team.name} fill className="object-cover" />

--- a/components/tournaments/management/tournament-detail-view.tsx
+++ b/components/tournaments/management/tournament-detail-view.tsx
@@ -112,9 +112,12 @@ export function TournamentDetailView({
     setRemovingTeamId(teamId);
 
     try {
-      const response = await fetch(`/api/admin/tournaments/${tournament.id}/teams?teamId=${teamId}`, {
-        method: "DELETE",
-      });
+      const response = await fetch(
+        `/api/admin/tournaments/${tournament.id}/teams?teamId=${teamId}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (!response.ok) {
         const data = await response.json();
@@ -396,9 +399,11 @@ export function TournamentDetailView({
                           <p className="font-medium">{getPublicUserDisplay(participant.user)}</p>
                           <p className="text-xs text-muted-foreground flex items-center gap-1">
                             {maskEmail(participant.user.email)}
-                            <Badge variant="outline" className="text-xs ml-1">
-                              Admin
-                            </Badge>
+                            {participant.user.is_admin && (
+                              <Badge variant="outline" className="text-xs ml-1">
+                                {tCommon("navigation.admin")}
+                              </Badge>
+                            )}
                           </p>
                         </div>
                         <Badge variant="secondary">

--- a/messages/en.json
+++ b/messages/en.json
@@ -479,6 +479,8 @@
       "message": "You are not currently registered as a participant in this tournament.",
       "contact": "Contact an administrator to be added to the participant list."
     },
+    "mustBeParticipant": "You must be a participant in this tournament to submit predictions.",
+    "notAuthorized": "You are not authorized to submit predictions for this tournament.",
     "completed": {
       "title": "Completed Matches",
       "subtitle": "View your predictions and points earned"

--- a/messages/es.json
+++ b/messages/es.json
@@ -479,6 +479,8 @@
       "message": "Actualmente no estás registrado como participante en este torneo.",
       "contact": "Contacta a un administrador para ser agregado a la lista de participantes."
     },
+    "mustBeParticipant": "Debes ser participante de este torneo para enviar pronósticos.",
+    "notAuthorized": "No estás autorizado para enviar pronósticos en este torneo.",
     "completed": {
       "title": "Partidos Completados",
       "subtitle": "Ve tus pronósticos y puntos ganados"

--- a/types/database.ts
+++ b/types/database.ts
@@ -129,6 +129,7 @@ export type PrivacyProtectedUser = Pick<
  */
 export type AdminUserView = PublicUserProfile & {
   email: string; // Masked email string
+  is_admin: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

A batch of UI bug fixes plus one small feature, all verified end-to-end in the local app (English + Spanish).

### Mobile navigation
- The mobile slide-out menu was clipped to the nav bar and unusable. The overlay + sidebar are now rendered via a React portal to `document.body`, escaping the nav's `backdrop-filter` containing block and `sticky z-50` stacking context.

### Predictions page
- **i18n:** the non-participant banner rendered raw keys (`notParticipant` was an object; `notParticipantMessage` didn't exist). Now uses `notParticipant.title` / `.message`, and adds `mustBeParticipant` / `notAuthorized` keys (EN + ES) for the defensive submit/403 paths.
- **Gating:** all match content is now hidden for non-participants — only the header + "Not a Participant" banner show (previously the Completed Matches section leaked if the user had past predictions).
- **Placeholder:** score inputs changed from `placeholder="0"` to `"#"` so an empty field isn't mistaken for a captured zero.

### Match displays
- **Away-team mirror:** added a `reverse` prop to `TeamBadge` (`flex-row-reverse`) and applied it to the away team across the match card, match detail view, prediction form, prediction result card, and rankings predictions view — so opposing teams render `[flag][name]` ↔ `[name][flag]` toward the score.
- **Scoring breakdown:** the match summary now shows *why* each participant earned their points (Exact score match! / Correct score difference! / Correct winner!), reusing the existing My Predictions pattern and `predictions.results.*` keys — no new strings or queries.

### Manage tournament
- The "Admin" badge was shown next to **every** participant. It now renders only for actual admins: `is_admin` is selected in the participants/`allUsers` queries, added to `AdminUserView`, and the badge is gated and localized via `common:navigation.admin`.

## Test plan
- `npm run lint` and `npm run type-check` pass (pre-existing `playwright.config.ts` dep errors are unrelated).
- Manually verified each change in the running app against local Supabase seed data, in both English and Spanish:
  - Mobile menu opens full-height over content and closes correctly.
  - Non-participant sees only header + banner; participant sees matches.
  - Empty score input shows `#`; away teams render mirrored.
  - Match summary shows the correct breakdown line per participant.
  - Admin badge appears only on the admin user.
- No new API routes/middleware; touched components are pure display, so no new tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)