### PR TITLE
fix(ui): make match cards responsive on small mobile screens

### DIFF
--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -69,12 +69,12 @@ export function MatchCard({ match }: MatchCardProps) {
 
             {/* Teams and Score */}
             <div className="flex items-center justify-between gap-4">
-              <div className={`flex-1 ${homeWins ? "font-semibold" : ""}`}>
+              <div className={`flex-1 min-w-0 ${homeWins ? "font-semibold" : ""}`}>
                 <TeamBadge team={match.home_team} size="md" showName={true} />
               </div>
 
               {isCompleted && match.home_score !== null && match.away_score !== null ? (
-                <div className="flex items-center gap-3 font-display text-3xl font-bold animate-score-pop">
+                <div className="flex items-center gap-3 font-display text-2xl sm:text-3xl font-bold animate-score-pop">
                   <span>{match.home_score}</span>
                   <span className="text-muted-foreground">:</span>
                   <span>{match.away_score}</span>
@@ -83,7 +83,7 @@ export function MatchCard({ match }: MatchCardProps) {
                 <div className="text-xl font-semibold text-muted-foreground">{tCommon("vs")}</div>
               )}
 
-              <div className={`flex-1 flex justify-end ${awayWins ? "font-semibold" : ""}`}>
+              <div className={`flex-1 min-w-0 flex justify-end ${awayWins ? "font-semibold" : ""}`}>
                 <TeamBadge team={match.away_team} size="md" showName={true} reverse={true} />
               </div>
             </div>

--- a/components/predictions/prediction-form.tsx
+++ b/components/predictions/prediction-form.tsx
@@ -76,7 +76,7 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
           <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               <TeamBadge team={match.home_team} size="sm" showName={true} />
             </div>
 
@@ -104,7 +104,7 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
               />
             </div>
 
-            <div className="flex-1 flex justify-end">
+            <div className="flex-1 min-w-0 flex justify-end">
               <TeamBadge team={match.away_team} size="sm" showName={true} reverse={true} />
             </div>
           </div>

--- a/components/predictions/prediction-result-card.tsx
+++ b/components/predictions/prediction-result-card.tsx
@@ -62,7 +62,7 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
         {/* Match Result */}
         <div className="space-y-2">
           <div className="flex items-center justify-between gap-4">
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               <TeamBadge team={match.home_team} size="sm" showName={true} />
             </div>
 
@@ -76,7 +76,7 @@ export function PredictionResultCard({ match, prediction }: PredictionResultCard
               </div>
             </div>
 
-            <div className="flex-1 flex justify-end">
+            <div className="flex-1 min-w-0 flex justify-end">
               <TeamBadge team={match.away_team} size="sm" showName={true} reverse={true} />
             </div>
           </div>

--- a/components/teams/team-badge.tsx
+++ b/components/teams/team-badge.tsx
@@ -24,8 +24,16 @@ export function TeamBadge({
   className,
 }: TeamBadgeProps) {
   return (
-    <div className={cn("flex items-center gap-2", reverse && "flex-row-reverse", className)}>
-      <div className={cn("relative rounded-full overflow-hidden border", sizeClasses[size])}>
+    <div
+      className={cn(
+        "flex items-center gap-2 min-w-0",
+        reverse && "flex-row-reverse",
+        className
+      )}
+    >
+      <div
+        className={cn("relative rounded-full overflow-hidden border shrink-0", sizeClasses[size])}
+      >
         {team.logo_url ? (
           <Image src={team.logo_url} alt={team.name} fill className="object-cover" />
         ) : (
@@ -35,16 +43,28 @@ export function TeamBadge({
         )}
       </div>
       {showName && (
-        <span
-          className={cn(
-            "font-medium",
-            size === "sm" && "text-sm",
-            size === "md" && "text-base",
-            size === "lg" && "text-lg"
-          )}
-        >
-          {team.name}
-        </span>
+        <>
+          <span
+            className={cn(
+              "font-medium sm:hidden",
+              size === "sm" && "text-sm",
+              size === "md" && "text-base",
+              size === "lg" && "text-lg"
+            )}
+          >
+            {team.short_name}
+          </span>
+          <span
+            className={cn(
+              "font-medium hidden sm:inline truncate",
+              size === "sm" && "text-sm",
+              size === "md" && "text-base",
+              size === "lg" && "text-lg"
+            )}
+          >
+            {team.name}
+          </span>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Context

On narrow mobile viewports the match cards broke in two ways:

1. **Long team names pushed card contents off to the right** — the name `<span>` in `TeamBadge` had no truncation and the surrounding `flex-1` wrappers lacked `min-w-0`, so flex children couldn't shrink below their intrinsic content width and overflowed.
2. **Flags distorted into ovals** — the fixed-size logo container had no `shrink-0`, so flexbox compressed it horizontally whenever a long name competed for the row's width.

## Changes

- **`components/teams/team-badge.tsx`** (shared core fix):
  - `shrink-0` on the logo container → flags stay circular regardless of sibling width.
  - `min-w-0` on the badge wrapper so truncation can engage.
  - Responsive name: `short_name` on mobile (`sm:hidden`), full `name` at `sm`+ (`hidden sm:inline truncate`).
- **Card layouts** — `min-w-0` added to each `flex-1` team wrapper so the shrink/truncate behavior propagates from the row into the badge:
  - `components/matches/match-card.tsx` (also: score scales `text-2xl` → `sm:text-3xl`)
  - `components/predictions/prediction-form.tsx`
  - `components/predictions/prediction-result-card.tsx`

No data/schema/type changes — reuses the existing `short_name` field.

## Validation

Ran the app against local Supabase and drove it with Playwright:

- **375px (mobile):** flags measured 40×40 / 24×24 (perfect circles, including a card with deliberately long names); short codes display; `document.body.scrollWidth === 375` with zero flag overflow.
- **768px (tablet+):** full names display ("Bosnia and Herzegovina Republic", "Democratic Republic of the Congo") with no overflow.
- Verified on all three surfaces: match list, prediction form, prediction result card.
- `npm run type-check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)