### PR TITLE
feat(predictions): add filters and improve My Predictions UX

### DIFF
--- a/app/(app)/(user)/[tournamentId]/predictions/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/predictions/page.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
-import { PredictionForm } from "@/components/predictions/prediction-form";
 import { PredictionResultCard } from "@/components/predictions/prediction-result-card";
+import { UpcomingMatchesFilters } from "@/components/predictions/upcoming-matches-filters";
+import { CollapsibleSection } from "@/components/predictions/collapsible-section";
 import { MatchWithTeams, Prediction } from "@/types/database";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 
 export default function PredictionsPage() {
@@ -131,6 +133,18 @@ export default function PredictionsPage() {
   // Filter completed matches to only show those with predictions
   const completedWithPredictions = completedMatches.filter((match) => predictions[match.id]);
 
+  // Upcoming progress summary
+  const totalUpcoming = scheduledMatches.length;
+  const predictedCount = scheduledMatches.filter((match) => predictions[match.id]).length;
+  const missingCount = totalUpcoming - predictedCount;
+
+  // Completed summary
+  const completedCount = completedWithPredictions.length;
+  const totalPoints = completedWithPredictions.reduce(
+    (sum, match) => sum + (predictions[match.id]?.points_earned ?? 0),
+    0
+  );
+
   return (
     <div className="container mx-auto py-8 px-4">
       <div className="mb-8 flex justify-between items-center">
@@ -152,13 +166,48 @@ export default function PredictionsPage() {
 
       {isParticipant && (
         <div className="space-y-12">
-          {/* Completed Matches Section */}
-          {completedWithPredictions.length > 0 && (
-            <div>
-              <div className="mb-4">
-                <h2 className="text-2xl font-bold">{t("completedMatches")}</h2>
-                <p className="text-sm text-muted-foreground">{t("completedMatchesSubtitle")}</p>
+          {/* Upcoming Matches Section (primary — what the user acts on) */}
+          <CollapsibleSection
+            title={t("upcomingMatches")}
+            subtitle={t("upcomingMatchesSubtitle")}
+            defaultOpen={true}
+            summary={
+              <span className="flex items-center gap-2">
+                <span>
+                  {t("summary.predictedOf", { predicted: predictedCount, total: totalUpcoming })}
+                </span>
+                {missingCount > 0 && (
+                  <Badge variant="outline" className="text-primary border-primary">
+                    {t("summary.missing", { count: missingCount })}
+                  </Badge>
+                )}
+              </span>
+            }
+          >
+            {scheduledMatches.length === 0 ? (
+              <div className="text-center py-12 border rounded-lg bg-muted/50">
+                <p className="text-muted-foreground">{t("noUpcomingMatches")}</p>
               </div>
+            ) : (
+              <UpcomingMatchesFilters
+                matches={scheduledMatches}
+                predictions={predictions}
+                onSubmitPrediction={handleSubmitPrediction}
+              />
+            )}
+          </CollapsibleSection>
+
+          {/* Completed Matches Section (secondary — grows over the tournament) */}
+          {completedWithPredictions.length > 0 && (
+            <CollapsibleSection
+              title={t("completedMatches")}
+              subtitle={t("completedMatchesSubtitle")}
+              defaultOpen={false}
+              summary={t("summary.matchesPoints", {
+                matches: completedCount,
+                points: totalPoints,
+              })}
+            >
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {completedWithPredictions.map((match) => (
                   <PredictionResultCard
@@ -168,32 +217,8 @@ export default function PredictionsPage() {
                   />
                 ))}
               </div>
-            </div>
+            </CollapsibleSection>
           )}
-
-          {/* Upcoming Matches Section */}
-          <div>
-            <div className="mb-4">
-              <h2 className="text-2xl font-bold">{t("upcomingMatches")}</h2>
-              <p className="text-sm text-muted-foreground">{t("upcomingMatchesSubtitle")}</p>
-            </div>
-            {scheduledMatches.length === 0 ? (
-              <div className="text-center py-12 border rounded-lg bg-muted/50">
-                <p className="text-muted-foreground">{t("noUpcomingMatches")}</p>
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {scheduledMatches.map((match) => (
-                  <PredictionForm
-                    key={match.id}
-                    match={match}
-                    existingPrediction={predictions[match.id]}
-                    onSubmit={(home, away) => handleSubmitPrediction(match.id, home, away)}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
         </div>
       )}
     </div>

--- a/components/predictions/collapsible-section.tsx
+++ b/components/predictions/collapsible-section.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useId, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+interface CollapsibleSectionProps {
+  title: string;
+  subtitle?: string;
+  /** Glanceable summary shown only when the section is collapsed. */
+  summary?: React.ReactNode;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+export function CollapsibleSection({
+  title,
+  subtitle,
+  summary,
+  defaultOpen = true,
+  children,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const contentId = useId();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        aria-controls={contentId}
+        className="w-full flex items-center gap-3 text-left mb-4"
+      >
+        {open ? (
+          <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        <div className="flex-1 min-w-0">
+          <h2 className="text-2xl font-bold">{title}</h2>
+          {open && subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+        </div>
+        {!open && summary && (
+          <div className="shrink-0 text-sm text-muted-foreground">{summary}</div>
+        )}
+      </button>
+
+      <div id={contentId} hidden={!open}>
+        {open && children}
+      </div>
+    </div>
+  );
+}

--- a/components/predictions/prediction-form.tsx
+++ b/components/predictions/prediction-form.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { formatLocalDateTime, isPastDate } from "@/lib/utils/date";
-import { Check, Lock } from "lucide-react";
+import { Check, Lock, Pencil } from "lucide-react";
 
 interface PredictionFormProps {
   match: MatchWithTeams;
@@ -34,6 +34,7 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
   const isPastMatchDate = isPastDate(match.match_date);
   const isCompleted = match.status === "completed";
   const isLocked = isPastMatchDate || isCompleted;
+  const needsPrediction = !existingPrediction && !isLocked;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,7 +49,11 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
   };
 
   return (
-    <Card className={isLocked ? "opacity-60" : ""}>
+    <Card
+      className={
+        isLocked ? "opacity-60" : needsPrediction ? "border-l-4 border-l-primary" : undefined
+      }
+    >
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-base">{formatLocalDateTime(match.match_date)}</CardTitle>
@@ -60,8 +65,14 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
             )}
             {existingPrediction && !isLocked && (
               <Badge variant="outline" className="text-success border-success">
-                <Check className="h-3 w-3 mr-1" />
+                <Check className="h-3 w-3 mr-1" aria-hidden="true" />
                 {t("form.predicted")}
+              </Badge>
+            )}
+            {needsPrediction && (
+              <Badge variant="outline" className="text-primary border-primary">
+                <Pencil className="h-3 w-3 mr-1" aria-hidden="true" />
+                {t("form.needsPrediction")}
               </Badge>
             )}
             {isLocked && (

--- a/components/predictions/upcoming-matches-filters.tsx
+++ b/components/predictions/upcoming-matches-filters.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { SlidersHorizontal, X } from "lucide-react";
+import { PredictionForm } from "@/components/predictions/prediction-form";
+import { MatchWithTeams, Prediction, Team } from "@/types/database";
+import { formatLocalDate } from "@/lib/utils/date";
+
+interface UpcomingMatchesFiltersProps {
+  matches: MatchWithTeams[];
+  predictions: Record<string, Prediction>;
+  onSubmitPrediction: (matchId: string, homeScore: number, awayScore: number) => Promise<void>;
+}
+
+const DATE_KEY_FORMAT = "yyyy-MM-dd";
+
+export function UpcomingMatchesFilters({
+  matches,
+  predictions,
+  onSubmitPrediction,
+}: UpcomingMatchesFiltersProps) {
+  const t = useTranslations("predictions");
+  const tCommon = useTranslations("common");
+
+  const [teamFilter, setTeamFilter] = useState<string>("all");
+  const [dateFilter, setDateFilter] = useState<string>("all");
+  const [roundFilter, setRoundFilter] = useState<string>("all");
+  const [emptyOnly, setEmptyOnly] = useState(false);
+
+  // Unique teams across all upcoming matches, sorted by name
+  const teams = useMemo(() => {
+    const byId = new Map<string, Team>();
+    matches.forEach((match) => {
+      byId.set(match.home_team.id, match.home_team);
+      byId.set(match.away_team.id, match.away_team);
+    });
+    return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [matches]);
+
+  // Unique match dates (keyed by local calendar day), sorted ascending
+  const dates = useMemo(() => {
+    const byKey = new Map<string, string>();
+    matches.forEach((match) => {
+      const key = formatLocalDate(match.match_date, DATE_KEY_FORMAT);
+      if (!byKey.has(key)) {
+        byKey.set(key, formatLocalDate(match.match_date));
+      }
+    });
+    return Array.from(byKey.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, label]) => ({ key, label }));
+  }, [matches]);
+
+  // Unique round labels, sorted
+  const rounds = useMemo(() => {
+    const unique = new Set<string>();
+    matches.forEach((match) => {
+      if (match.round) unique.add(match.round);
+    });
+    return Array.from(unique).sort();
+  }, [matches]);
+
+  const filteredMatches = useMemo(() => {
+    return matches.filter((match) => {
+      if (
+        teamFilter !== "all" &&
+        match.home_team_id !== teamFilter &&
+        match.away_team_id !== teamFilter
+      ) {
+        return false;
+      }
+      if (
+        dateFilter !== "all" &&
+        formatLocalDate(match.match_date, DATE_KEY_FORMAT) !== dateFilter
+      ) {
+        return false;
+      }
+      if (roundFilter !== "all" && match.round !== roundFilter) {
+        return false;
+      }
+      // "Empty" = no prediction record exists for this match yet
+      if (emptyOnly && predictions[match.id]) {
+        return false;
+      }
+      return true;
+    });
+  }, [matches, teamFilter, dateFilter, roundFilter, emptyOnly, predictions]);
+
+  const hasActiveFilters =
+    teamFilter !== "all" || dateFilter !== "all" || roundFilter !== "all" || emptyOnly;
+
+  const clearFilters = () => {
+    setTeamFilter("all");
+    setDateFilter("all");
+    setRoundFilter("all");
+    setEmptyOnly(false);
+  };
+
+  const selectedTeamName = teams.find((team) => team.id === teamFilter)?.name;
+  const selectedDateLabel = dates.find((date) => date.key === dateFilter)?.label;
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-base font-semibold">
+            <SlidersHorizontal className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            {t("filters.heading")}
+          </h3>
+          <p className="text-sm text-muted-foreground">{t("filters.description")}</p>
+        </div>
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-4">
+          <Select value={teamFilter} onValueChange={setTeamFilter}>
+            <SelectTrigger className="w-full sm:w-[200px]" aria-label={t("filters.filterByTeam")}>
+              <SelectValue placeholder={t("filters.filterByTeam")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("filters.allTeams")}</SelectItem>
+              {teams.map((team) => (
+                <SelectItem key={team.id} value={team.id}>
+                  {team.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={dateFilter} onValueChange={setDateFilter}>
+            <SelectTrigger className="w-full sm:w-[200px]" aria-label={t("filters.filterByDate")}>
+              <SelectValue placeholder={t("filters.filterByDate")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("filters.allDates")}</SelectItem>
+              {dates.map((date) => (
+                <SelectItem key={date.key} value={date.key}>
+                  {date.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {rounds.length > 0 && (
+            <Select value={roundFilter} onValueChange={setRoundFilter}>
+              <SelectTrigger
+                className="w-full sm:w-[200px]"
+                aria-label={t("filters.filterByRound")}
+              >
+                <SelectValue placeholder={t("filters.filterByRound")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("filters.allRounds")}</SelectItem>
+                {rounds.map((round) => (
+                  <SelectItem key={round} value={round}>
+                    {round}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          <div className="flex items-center gap-2 sm:h-10">
+            <input
+              type="checkbox"
+              id="empty-predictions-only"
+              checked={emptyOnly}
+              onChange={(e) => setEmptyOnly(e.target.checked)}
+              className="h-4 w-4 rounded border-input accent-primary"
+            />
+            <Label htmlFor="empty-predictions-only" className="cursor-pointer">
+              {t("filters.emptyOnly")}
+            </Label>
+          </div>
+        </div>
+
+        {/* Active filters */}
+        {hasActiveFilters && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm text-muted-foreground">
+              {tCommon("filters.activeFilters")}:
+            </span>
+            {teamFilter !== "all" && (
+              <Badge variant="secondary" className="gap-1">
+                {t("filters.team")}: {selectedTeamName}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto p-0 ml-1 hover:text-destructive"
+                  onClick={() => setTeamFilter("all")}
+                  aria-label={t("filters.removeTeamFilter")}
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </Button>
+              </Badge>
+            )}
+            {dateFilter !== "all" && (
+              <Badge variant="secondary" className="gap-1">
+                {tCommon("labels.date")}: {selectedDateLabel}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto p-0 ml-1 hover:text-destructive"
+                  onClick={() => setDateFilter("all")}
+                  aria-label={t("filters.removeDateFilter")}
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </Button>
+              </Badge>
+            )}
+            {roundFilter !== "all" && (
+              <Badge variant="secondary" className="gap-1">
+                {t("filters.round")}: {roundFilter}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto p-0 ml-1 hover:text-destructive"
+                  onClick={() => setRoundFilter("all")}
+                  aria-label={t("filters.removeRoundFilter")}
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </Button>
+              </Badge>
+            )}
+            {emptyOnly && (
+              <Badge variant="secondary" className="gap-1">
+                {t("filters.emptyOnly")}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto p-0 ml-1 hover:text-destructive"
+                  onClick={() => setEmptyOnly(false)}
+                  aria-label={t("filters.removeEmptyFilter")}
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </Button>
+              </Badge>
+            )}
+            <Button variant="link" size="sm" className="h-auto p-0 text-sm" onClick={clearFilters}>
+              {tCommon("actions.clearAll")}
+            </Button>
+          </div>
+        )}
+
+        {/* Results counter */}
+        <p className="text-sm text-muted-foreground">
+          {tCommon("filters.showingOf", {
+            showing: filteredMatches.length,
+            total: matches.length,
+            item: tCommon("labels.matches"),
+          })}
+        </p>
+      </div>
+
+      {/* Matches grid */}
+      {filteredMatches.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {filteredMatches.map((match) => (
+            <PredictionForm
+              key={match.id}
+              match={match}
+              existingPrediction={predictions[match.id]}
+              onSubmit={(home, away) => onSubmitPrediction(match.id, home, away)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12 border rounded-lg bg-muted/50">
+          <p className="text-muted-foreground">{t("filters.noMatchesFiltered")}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -474,6 +474,30 @@
     "upcomingMatchesSubtitle": "Submit your score predictions before matches start",
     "completedMatches": "Completed Matches",
     "completedMatchesSubtitle": "View your predictions and points earned",
+    "noUpcomingMatches": "No upcoming matches available for predictions.",
+    "filters": {
+      "heading": "Filter matches",
+      "description": "Narrow down the upcoming matches to find the ones you want to predict.",
+      "filterByTeam": "Filter by team",
+      "allTeams": "All teams",
+      "team": "Team",
+      "removeTeamFilter": "Remove team filter",
+      "filterByDate": "Filter by date",
+      "allDates": "All dates",
+      "removeDateFilter": "Remove date filter",
+      "filterByRound": "Filter by stage",
+      "allRounds": "All Stages",
+      "round": "Stage",
+      "removeRoundFilter": "Remove stage filter",
+      "emptyOnly": "Only without prediction",
+      "removeEmptyFilter": "Remove empty predictions filter",
+      "noMatchesFiltered": "No matches match the selected filters"
+    },
+    "summary": {
+      "predictedOf": "{predicted}/{total} predicted",
+      "missing": "{count} missing",
+      "matchesPoints": "{matches} matches · {points} pts"
+    },
     "notParticipant": {
       "title": "Not a Participant",
       "message": "You are not currently registered as a participant in this tournament.",
@@ -495,6 +519,7 @@
       "updatePrediction": "Update Prediction",
       "saving": "Saving...",
       "predicted": "Predicted",
+      "needsPrediction": "Needs prediction",
       "locked": "Locked"
     },
     "results": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -474,6 +474,30 @@
     "upcomingMatchesSubtitle": "Envía tus pronósticos de puntuación antes de que comiencen los partidos",
     "completedMatches": "Partidos Completados",
     "completedMatchesSubtitle": "Ve tus pronósticos y puntos ganados",
+    "noUpcomingMatches": "No hay próximos partidos disponibles para pronósticos.",
+    "filters": {
+      "heading": "Filtrar partidos",
+      "description": "Acota los próximos partidos para encontrar los que quieres pronosticar.",
+      "filterByTeam": "Filtrar por equipo",
+      "allTeams": "Todos los equipos",
+      "team": "Equipo",
+      "removeTeamFilter": "Quitar filtro de equipo",
+      "filterByDate": "Filtrar por fecha",
+      "allDates": "Todas las fechas",
+      "removeDateFilter": "Quitar filtro de fecha",
+      "filterByRound": "Filtrar por fase",
+      "allRounds": "Todas las Fases",
+      "round": "Fase",
+      "removeRoundFilter": "Quitar filtro de fase",
+      "emptyOnly": "Solo sin pronóstico",
+      "removeEmptyFilter": "Quitar filtro de pronósticos vacíos",
+      "noMatchesFiltered": "Ningún partido coincide con los filtros seleccionados"
+    },
+    "summary": {
+      "predictedOf": "{predicted}/{total} pronosticados",
+      "missing": "{count} faltantes",
+      "matchesPoints": "{matches} partidos · {points} pts"
+    },
     "notParticipant": {
       "title": "No Eres Participante",
       "message": "Actualmente no estás registrado como participante en este torneo.",
@@ -495,6 +519,7 @@
       "updatePrediction": "Actualizar Pronóstico",
       "saving": "Guardando...",
       "predicted": "Pronosticado",
+      "needsPrediction": "Falta pronóstico",
       "locked": "Bloqueado"
     },
     "results": {


### PR DESCRIPTION
## Summary

Improvements to the **My Predictions** view so users can quickly see what needs doing and find specific matches.

- **Filter bar on Upcoming Matches** — filter by **team**, **date**, **stage**, plus an **empty-predictions-only** toggle. Modeled on the existing admin match-management filter pattern (Select dropdowns + active-filter badges + results counter). Includes a "Filter matches" header explaining its use.
- **Inverted section order** — Upcoming Matches first, Completed Matches second, matching the actual user flow (act on upcoming; completed grows over time).
- **Collapsible sections** — both sections collapse to a glanceable summary: Upcoming shows predicted/total + a "missing" badge; Completed shows match count + total points. Upcoming defaults open, Completed defaults collapsed.
- **Missing-prediction cues** — upcoming cards with no prediction yet (and still open) get an accent border + a "Needs prediction" badge so actionable matches stand out (not color-only).
- **Localization** — new en/es strings; also backfilled the missing `noUpcomingMatches` key used by the empty state.

## New files
- `components/predictions/collapsible-section.tsx` — reusable collapsible wrapper (accessible button header, `aria-expanded`/`aria-controls`).
- `components/predictions/upcoming-matches-filters.tsx` — filter UI + grid.

## Accessibility
- Collapsible headers are real buttons with `aria-expanded`/`aria-controls`; chevrons `aria-hidden`.
- Every `SelectTrigger` has an `aria-label`; the empty-only checkbox has an associated `<label>`.
- Highlight pairs color with a text/icon badge.

## Verification
- `npm run type-check` clean (excluding pre-existing unrelated `playwright.config.ts` errors)
- `npx eslint` and `npx prettier --check` clean on changed files
- Manually verified against local Supabase: filters narrow/stack correctly, empty toggle works, sections collapse with correct summaries, progress/missing cues update on submit, and Spanish strings render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)