### PR TITLE
feat(navigation): history-aware back, breadcrumbs, and real 404s

### DIFF
--- a/app/(app)/(user)/[tournamentId]/matches/[matchId]/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/matches/[matchId]/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { notFound } from "next/navigation";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { MatchDetailView } from "@/components/matches/match-detail-view";
 import { getTranslations } from "next-intl/server";
 
@@ -11,6 +11,7 @@ export default async function MatchDetailPage({
   params: Promise<{ tournamentId: string; matchId: string }>;
 }) {
   const t = await getTranslations("matches");
+  const tCommon = await getTranslations("common");
   const { tournamentId, matchId } = await params;
   const supabase = await createClient();
 
@@ -32,7 +33,7 @@ export default async function MatchDetailPage({
     .single();
 
   if (matchError || !match) {
-    redirect(`/${tournamentId}/matches`);
+    notFound();
   }
 
   // Fetch tournament for display
@@ -53,16 +54,24 @@ export default async function MatchDetailPage({
     )
     .eq("match_id", matchId);
 
+  const matchLabel = `${match.home_team.name} ${tCommon("vs")} ${match.away_team.name}`;
+
   return (
     <div className="container mx-auto py-8 px-4">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament?.name ?? ""}
+        items={[
+          { label: t("title"), href: `/${tournamentId}/matches` },
+          { label: matchLabel },
+        ]}
+      />
       <div className="mb-8 flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold mb-2">{t("matchSummary")}</h1>
           <p className="text-muted-foreground">{tournament?.name}</p>
         </div>
-        <Link href={`/${tournamentId}/matches`}>
-          <Button variant="outline">{t("backToMatches")}</Button>
-        </Link>
+        <BackButton fallbackHref={`/${tournamentId}/matches`} />
       </div>
       <MatchDetailView
         match={match}

--- a/app/(app)/(user)/[tournamentId]/matches/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/matches/page.tsx
@@ -1,7 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
 import { MatchList } from "@/components/matches/match-list";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { getTranslations } from "next-intl/server";
 
 export default async function MatchesPage({
@@ -19,6 +20,10 @@ export default async function MatchesPage({
     .eq("id", tournamentId)
     .single();
 
+  if (!tournament) {
+    notFound();
+  }
+
   const { data: matches } = await supabase
     .from("matches")
     .select(
@@ -33,15 +38,18 @@ export default async function MatchesPage({
 
   return (
     <div className="container mx-auto py-8 px-4">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament?.name ?? ""}
+        items={[{ label: t("title") }]}
+      />
       <div className="mb-8 flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold mb-2">{tournament?.name}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>
         </div>
         <div className="flex gap-2">
-          <Link href={`/${tournamentId}`}>
-            <Button variant="outline">{t("backToTournament")}</Button>
-          </Link>
+          <BackButton fallbackHref={`/${tournamentId}`} />
         </div>
       </div>
       <MatchList matches={matches || []} />

--- a/app/(app)/(user)/[tournamentId]/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/page.tsx
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { TournamentDashboard } from "@/components/tournaments/tournament-dashboard";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 
 export default async function TournamentPage({
   params,
@@ -22,7 +22,7 @@ export default async function TournamentPage({
     .single();
 
   if (!tournament) {
-    redirect("/tournaments");
+    notFound();
   }
 
   // Fetch matches with teams

--- a/app/(app)/(user)/[tournamentId]/predictions/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/predictions/page.tsx
@@ -4,17 +4,21 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
+import { useFeatureToast } from "@/lib/hooks/use-feature-toast";
 import { PredictionResultCard } from "@/components/predictions/prediction-result-card";
 import { UpcomingMatchesFilters } from "@/components/predictions/upcoming-matches-filters";
 import { CollapsibleSection } from "@/components/predictions/collapsible-section";
 import { MatchWithTeams, Prediction } from "@/types/database";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import Link from "next/link";
 
 export default function PredictionsPage() {
   const t = useTranslations("predictions");
   const tCommon = useTranslations("common");
+  const toast = useFeatureToast("predictions");
   const params = useParams();
   const tournamentId = params.tournamentId as string;
   const [scheduledMatches, setScheduledMatches] = useState<MatchWithTeams[]>([]);
@@ -22,6 +26,7 @@ export default function PredictionsPage() {
   const [predictions, setPredictions] = useState<Record<string, Prediction>>({});
   const [loading, setLoading] = useState(true);
   const [isParticipant, setIsParticipant] = useState(true);
+  const [tournamentName, setTournamentName] = useState("");
   const supabase = createClient();
 
   const loadData = useCallback(async () => {
@@ -41,6 +46,15 @@ export default function PredictionsPage() {
       .single();
 
     setIsParticipant(!!participant);
+
+    // Load tournament name for the breadcrumb trail
+    const { data: tournament } = await supabase
+      .from("tournaments")
+      .select("name")
+      .eq("id", tournamentId)
+      .single();
+
+    setTournamentName(tournament?.name ?? "");
 
     // Load scheduled matches
     const { data: scheduledMatchesData } = await supabase
@@ -99,9 +113,11 @@ export default function PredictionsPage() {
 
   async function handleSubmitPrediction(matchId: string, homeScore: number, awayScore: number) {
     if (!isParticipant) {
-      alert(t("mustBeParticipant"));
+      toast.error("error.mustBeParticipant");
       return;
     }
+
+    const isUpdate = !!predictions[matchId];
 
     const response = await fetch("/api/predictions", {
       method: "POST",
@@ -114,10 +130,10 @@ export default function PredictionsPage() {
     });
 
     if (response.ok) {
+      toast.success(isUpdate ? "success.updated" : "success.submitted");
       loadData();
     } else if (response.status === 403) {
-      const data = await response.json();
-      alert(data.error || t("notAuthorized"));
+      toast.error("error.notAuthorized");
       setIsParticipant(false);
     }
   }
@@ -147,20 +163,27 @@ export default function PredictionsPage() {
 
   return (
     <div className="container mx-auto py-8 px-4">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournamentName}
+        items={[{ label: t("title") }]}
+      />
       <div className="mb-8 flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold mb-2">{t("title")}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>
         </div>
-        <Link href={`/${tournamentId}`}>
-          <Button variant="outline">{t("backToTournament")}</Button>
-        </Link>
+        <BackButton fallbackHref={`/${tournamentId}`} />
       </div>
 
       {!isParticipant && (
         <div className="mb-8 p-6 bg-muted/50 border rounded-lg text-center">
           <h3 className="text-lg font-semibold mb-2">{t("notParticipant.title")}</h3>
           <p className="text-muted-foreground">{t("notParticipant.message")}</p>
+          <p className="text-muted-foreground mt-2">{t("notParticipant.contact")}</p>
+          <Link href={`/${tournamentId}`} className="inline-block mt-4">
+            <Button variant="outline">{t("backToTournament")}</Button>
+          </Link>
         </div>
       )}
 

--- a/app/(app)/(user)/[tournamentId]/rankings/[userId]/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/[userId]/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { notFound } from "next/navigation";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { UserPredictionsView } from "@/components/rankings/user-predictions-view";
 import { getPublicUserDisplay } from "@/lib/utils/privacy";
 import { getTranslations } from "next-intl/server";
@@ -27,7 +27,7 @@ export default async function UserRankingDetailPage({
     .single();
 
   if (!tournament) {
-    redirect(`/${tournamentId}/rankings`);
+    notFound();
   }
 
   // Fetch the user being viewed (explicit field selection for privacy)
@@ -38,7 +38,7 @@ export default async function UserRankingDetailPage({
     .single();
 
   if (!viewedUser) {
-    redirect(`/${tournamentId}/rankings`);
+    notFound();
   }
 
   // Fetch user's ranking in this tournament
@@ -70,6 +70,14 @@ export default async function UserRankingDetailPage({
 
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament.name}
+        items={[
+          { label: t("breadcrumb"), href: `/${tournamentId}/rankings` },
+          { label: getPublicUserDisplay(viewedUser) },
+        ]}
+      />
       <div className="mb-8 flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold mb-2">
@@ -84,9 +92,7 @@ export default async function UserRankingDetailPage({
             {t("userPredictions.predictionsFor", { tournament: tournament.name })}
           </p>
         </div>
-        <Link href={`/${tournamentId}/rankings`}>
-          <Button variant="outline">{t("backToRankings")}</Button>
-        </Link>
+        <BackButton fallbackHref={`/${tournamentId}/rankings`} />
       </div>
       <UserPredictionsView
         user={viewedUser}

--- a/app/(app)/(user)/[tournamentId]/rankings/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/page.tsx
@@ -1,8 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
 import { RankingsTable } from "@/components/rankings/rankings-table";
 import { RankingWithPublicUser } from "@/types/database";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { getTranslations } from "next-intl/server";
 
 export default async function RankingsPage({
@@ -24,6 +25,10 @@ export default async function RankingsPage({
     .eq("id", tournamentId)
     .single();
 
+  if (!tournament) {
+    notFound();
+  }
+
   const { data: rankings } = await supabase
     .from("tournament_rankings")
     .select(
@@ -37,15 +42,18 @@ export default async function RankingsPage({
 
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament?.name ?? ""}
+        items={[{ label: t("breadcrumb") }]}
+      />
       <div className="mb-8 flex justify-between items-center">
         <div>
           <h1 className="text-4xl font-bold mb-2">{tournament?.name}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>
         </div>
         <div className="flex gap-2">
-          <Link href={`/${tournamentId}`}>
-            <Button variant="outline">{t("backToTournament")}</Button>
-          </Link>
+          <BackButton fallbackHref={`/${tournamentId}`} />
         </div>
       </div>
       <RankingsTable

--- a/components/layout/app-nav.tsx
+++ b/components/layout/app-nav.tsx
@@ -28,6 +28,17 @@ export function AppNav({ user }: AppNavProps) {
 
   const isActive = (href: string) => pathname === href || pathname.startsWith(href + "/");
 
+  // Top-level routes that are NOT tournament dashboards. A tournament dashboard
+  // lives at the root level (`/{tournamentId}`), so any first path segment not in
+  // this set is treated as tournament context for the active-nav indicator.
+  const STATIC_TOP_LEVEL = new Set(["tournaments", "teams", "admin", "profile", "unauthorized"]);
+  const firstSegment = pathname.split("/")[1] ?? "";
+  const isManage = pathname.startsWith("/tournaments/manage");
+  const isTournamentContext =
+    !isManage &&
+    (firstSegment === "tournaments" ||
+      (firstSegment !== "" && !STATIC_TOP_LEVEL.has(firstSegment)));
+
   return (
     <nav className="border-b bg-background/80 backdrop-blur-md sticky top-0 z-50">
       <div className="container mx-auto px-4 py-3 flex justify-between items-center">
@@ -44,7 +55,7 @@ export function AppNav({ user }: AppNavProps) {
           <Link
             href="/tournaments"
             className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-              isActive("/tournaments") && !pathname.includes("/manage")
+              isTournamentContext
                 ? "text-primary border-b-2 border-primary"
                 : "text-muted-foreground hover:text-foreground"
             }`}

--- a/components/layout/back-button.tsx
+++ b/components/layout/back-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface BackButtonProps {
+  /**
+   * Canonical parent route to navigate to when there is no in-app history to
+   * return to (deep link, page refresh, or external entry).
+   */
+  fallbackHref: string;
+  /** Optional override label. Defaults to the shared `common:actions.back` string. */
+  label?: string;
+}
+
+/**
+ * History-aware back button. Returns the user to wherever they actually came
+ * from (`router.back()`) when an in-app history entry exists, and otherwise
+ * falls back to the canonical parent route so deep links never dead-end.
+ */
+export function BackButton({ fallbackHref, label }: BackButtonProps) {
+  const router = useRouter();
+  const tCommon = useTranslations("common");
+
+  function handleClick() {
+    // Next.js stores an incrementing `idx` on the history state. `idx > 0`
+    // means there is a previous in-app entry to return to; `idx === 0` (or
+    // undefined) means this was the first entry in the session.
+    const idx =
+      typeof window !== "undefined"
+        ? (window.history.state as { idx?: number } | null)?.idx
+        : undefined;
+
+    if (typeof idx === "number" && idx > 0) {
+      router.back();
+    } else {
+      router.push(fallbackHref);
+    }
+  }
+
+  return (
+    <Button variant="outline" onClick={handleClick}>
+      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+      {label ?? tCommon("actions.back")}
+    </Button>
+  );
+}

--- a/components/layout/tournament-breadcrumbs.tsx
+++ b/components/layout/tournament-breadcrumbs.tsx
@@ -1,0 +1,63 @@
+import { Fragment } from "react";
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+export interface BreadcrumbCrumb {
+  label: string;
+  /** Omit on the current (last) page so it renders as plain text. */
+  href?: string;
+}
+
+interface TournamentBreadcrumbsProps {
+  tournamentId: string;
+  tournamentName: string;
+  /** Trailing crumbs after the tournament name; the last one is the current page. */
+  items?: BreadcrumbCrumb[];
+}
+
+/**
+ * Breadcrumb trail for tournament sub-pages. The tournament name always links
+ * back to the tournament summary (`/{tournamentId}`), giving every child page an
+ * explicit path home regardless of how the user arrived.
+ */
+export function TournamentBreadcrumbs({
+  tournamentId,
+  tournamentName,
+  items = [],
+}: TournamentBreadcrumbsProps) {
+  return (
+    <Breadcrumb className="mb-6">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/${tournamentId}`}>{tournamentName}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        {items.map((crumb, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <Fragment key={`${crumb.label}-${index}`}>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {isLast || !crumb.href ? (
+                  <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink asChild>
+                    <Link href={crumb.href}>{crumb.label}</Link>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode;
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = "Breadcrumb";
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+));
+BreadcrumbList.displayName = "BreadcrumbList";
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("inline-flex items-center gap-1.5", className)} {...props} />
+));
+BreadcrumbItem.displayName = "BreadcrumbItem";
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean;
+  }
+>(({ asChild, className, children, ...props }, ref) => {
+  const mergedClassName = cn("transition-colors hover:text-foreground", className);
+
+  // `asChild` merges styling onto a single child element (e.g. a Next.js
+  // <Link>) without pulling in @radix-ui/react-slot.
+  if (asChild && React.isValidElement(children)) {
+    const child = children as React.ReactElement<{ className?: string }>;
+    return React.cloneElement(child, {
+      className: cn(mergedClassName, child.props.className),
+    });
+  }
+
+  return (
+    <a ref={ref} className={mergedClassName} {...props}>
+      {children}
+    </a>
+  );
+});
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+));
+BreadcrumbPage.displayName = "BreadcrumbPage";
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:size-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+);
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
+const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+);
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis";
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/messages/en.json
+++ b/messages/en.json
@@ -463,7 +463,9 @@
       },
       "error": {
         "failedToSubmit": "Failed to submit prediction",
-        "failedToUpdate": "Failed to update prediction"
+        "failedToUpdate": "Failed to update prediction",
+        "mustBeParticipant": "You must be a participant in this tournament to submit predictions.",
+        "notAuthorized": "You are not authorized to submit predictions for this tournament."
       },
       "info": {
         "alreadySubmitted": "Prediction already submitted"
@@ -534,6 +536,7 @@
   },
   "rankings": {
     "title": "Tournament Leaderboard",
+    "breadcrumb": "Rankings",
     "subtitle": "See how you rank against other players",
     "backToTournament": "Back to Tournament",
     "backToRankings": "Back to Rankings",

--- a/messages/es.json
+++ b/messages/es.json
@@ -463,7 +463,9 @@
       },
       "error": {
         "failedToSubmit": "Error al enviar el pronóstico",
-        "failedToUpdate": "Error al actualizar pronóstico"
+        "failedToUpdate": "Error al actualizar pronóstico",
+        "mustBeParticipant": "Debes ser participante de este torneo para enviar pronósticos.",
+        "notAuthorized": "No estás autorizado para enviar pronósticos en este torneo."
       },
       "info": {
         "alreadySubmitted": "Pronóstico ya enviado"
@@ -534,6 +536,7 @@
   },
   "rankings": {
     "title": "Tabla de Posiciones del Torneo",
+    "breadcrumb": "Clasificaciones",
     "subtitle": "Mira cómo te clasificas contra otros jugadores",
     "backToTournament": "Volver al Torneo",
     "backToRankings": "Volver a Clasificaciones",


### PR DESCRIPTION
## Summary

Fixes broken tournament navigation flows surfaced from a navigation-flow review. Two iterations, all changes are display/UX-level (no schema, no route restructure, no participation-model change).

### Iteration 1 — back navigation & sense of place
- **History-aware `BackButton`** ([components/layout/back-button.tsx](components/layout/back-button.tsx)): returns the user to where they actually came from via `router.back()` when in-app history exists, falling back to the canonical parent route on deep links / refresh. Replaces hardcoded `<Link>` "Back" buttons that always pointed at one assumed parent — e.g. match detail always bounced to the matches list even when you arrived from the dashboard or a player's predictions.
- **Breadcrumbs** on every tournament sub-page ([components/layout/tournament-breadcrumbs.tsx](components/layout/tournament-breadcrumbs.tsx) + a new [components/ui/breadcrumb.tsx](components/ui/breadcrumb.tsx) primitive). The tournament name links back to the summary — the previously-missing explicit path home.
- **Active-nav fix** ([components/layout/app-nav.tsx](components/layout/app-nav.tsx)): the top "Tournaments" item now highlights while anywhere inside a tournament (root-level `/{tournamentId}` context), via a centralized static-route list.

### Iteration 2 — predictions UX & routing 404s
- **Predictions** ([predictions/page.tsx](app/(app)/(user)/[tournamentId]/predictions/page.tsx)): non-participants now see the "contact an administrator" guidance (string existed but was never rendered) plus a button back to the tournament; the two raw `alert()` calls are replaced with localized `useFeatureToast` toasts; and a success toast now confirms submit/update.
- **Routing**: invalid tournament/match/user IDs now return a real **404** (`notFound()`) instead of silently redirecting to a list page (an unknown root URL previously matched `[tournamentId]` and bounced to `/tournaments`).

## Verification
- `npm run type-check`, ESLint, and `npm test` (**182 passing**) all green.
- Live (authenticated, Playwright): `/some-invalid-id` and an invalid match ID both render the 404 page; predictions page shows the breadcrumb trail + history-aware Back; updating a prediction runs the success path with no native `alert()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)