### PR TITLE
feat(predictions): add multiplier badge to prediction form cards

### DIFF
--- a/components/predictions/prediction-form.tsx
+++ b/components/predictions/prediction-form.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { formatLocalDateTime, isPastDate } from "@/lib/utils/date";
-import { Check, Lock, Pencil } from "lucide-react";
+import { Check, Lock, Pencil, Zap } from "lucide-react";
 
 interface PredictionFormProps {
   match: MatchWithTeams;
@@ -61,6 +61,12 @@ export function PredictionForm({ match, existingPrediction, onSubmit }: Predicti
             {match.round && (
               <Badge variant="outline" className="text-xs">
                 {match.round}
+              </Badge>
+            )}
+            {match.multiplier > 1 && (
+              <Badge variant="outline" className="text-warning border-warning">
+                <Zap className="h-3 w-3 mr-0.5" aria-hidden="true" />
+                {match.multiplier}x
               </Badge>
             )}
             {existingPrediction && !isLocked && (


### PR DESCRIPTION
## Summary
- Adds the multiplier badge to the prediction form cards, matching the formatting used on the match cards
- The badge uses the same warning styling (`text-warning border-warning`), `Zap` icon, and `{multiplier}x` label, and only renders when `match.multiplier > 1`

## Notes
- Icon is marked `aria-hidden="true"` to align with the form's accessibility conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)