### PR TITLE
feat(matches): reveal predictions once a match is in progress

### DIFF
--- a/components/matches/match-detail-view.tsx
+++ b/components/matches/match-detail-view.tsx
@@ -189,7 +189,8 @@ function PredictionRow({
       .slice(0, 2);
   };
 
-  const showPrediction = isCompleted || isCancelled || isCurrentUser;
+  const isLive = match.status === "in_progress";
+  const showPrediction = isLive || isCompleted || isCancelled || isCurrentUser;
   const showBreakdown =
     showPrediction && isCompleted && !isCancelled && prediction.points_earned > 0;
 
@@ -245,7 +246,7 @@ function PredictionRow({
             </>
           ) : (
             <div className="text-center">
-              <span className="text-muted-foreground italic text-sm">{t("hiddenUntilEnd")}</span>
+              <span className="text-muted-foreground italic text-sm">{t("hiddenUntilStart")}</span>
             </div>
           )}
         </div>

--- a/components/rankings/user-predictions-view.tsx
+++ b/components/rankings/user-predictions-view.tsx
@@ -134,7 +134,7 @@ export function UserPredictionsView({
                 <PredictionRow
                   key={prediction.id}
                   prediction={prediction}
-                  showDetails={isCurrentUser}
+                  showDetails={isCurrentUser || prediction.match.status !== "scheduled"}
                 />
               ))}
             </div>

--- a/components/tournaments/tournament-dashboard.tsx
+++ b/components/tournaments/tournament-dashboard.tsx
@@ -51,7 +51,9 @@ export function TournamentDashboard({
   const t = useTranslations("tournaments");
   const tCommon = useTranslations("common");
 
-  const upcomingMatches = matches.filter((m) => m.status === "scheduled").slice(0, 5);
+  const upcomingMatches = matches
+    .filter((m) => m.status === "scheduled" || m.status === "in_progress")
+    .slice(0, 5);
   const recentMatches = matches
     .filter((m) => m.status === "completed")
     .slice(-5)

--- a/messages/en.json
+++ b/messages/en.json
@@ -403,7 +403,7 @@
       "noPredictions": "No predictions have been submitted for this match yet.",
       "multiplierNote": "This match has a {multiplier}x scoring multiplier! Points earned will be multiplied accordingly.",
       "you": "(You)",
-      "hiddenUntilEnd": "Hidden until match ends",
+      "hiddenUntilStart": "Hidden until the match is in progress",
       "anonymous": "Anonymous"
     },
     "management": {
@@ -530,7 +530,7 @@
       "exactMatch": "Exact score match!",
       "correctDifference": "Correct score difference!",
       "correctWinner": "Correct winner!",
-      "predictionHidden": "Prediction hidden",
+      "predictionHidden": "Hidden until the match is in progress",
       "pointsEarned": "{points} points earned"
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -403,7 +403,7 @@
       "noPredictions": "Aún no se han enviado pronósticos para este partido.",
       "multiplierNote": "¡Este partido tiene un multiplicador de puntuación de {multiplier}x! Los puntos ganados en consecuencia.",
       "you": "(Tú)",
-      "hiddenUntilEnd": "Oculto hasta que termine el partido",
+      "hiddenUntilStart": "Oculto hasta que el partido esté en juego",
       "anonymous": "Anónimo"
     },
     "management": {
@@ -530,7 +530,7 @@
       "exactMatch": "¡Puntuación exacta!",
       "correctDifference": "¡Diferencia de goles correcta!",
       "correctWinner": "¡Ganador correcto!",
-      "predictionHidden": "Pronóstico oculta",
+      "predictionHidden": "Oculto hasta que el partido esté en juego",
       "pointsEarned": "{points} puntos ganados"
     }
   },


### PR DESCRIPTION
## Summary

Changes prediction visibility so other users' predictions are hidden **only while a match is `scheduled`** (the stage where predictions can still be entered/edited). Once a match flips to `in_progress` (or `completed`/`cancelled`), everyone's predictions become visible — letting users compare predictions as soon as a match is at play. A user always sees their own prediction regardless of status.

## Changes

- **Match detail** (`components/matches/match-detail-view.tsx`): reveal predictions for in-progress matches (`isLive`), not just completed/cancelled.
- **User predictions list** (`components/rankings/user-predictions-view.tsx`): reveal details for any non-`scheduled` match to viewers, while keeping scheduled predictions hidden for others.
- **Tournament dashboard** (`components/tournaments/tournament-dashboard.tsx`): the "Upcoming Matches" card now includes `in_progress` matches, so currently-playing matches stay on the front page instead of disappearing.
- **i18n** (`messages/en.json`, `messages/es.json`): renamed `matches.details.hiddenUntilEnd` → `hiddenUntilStart` and updated both it and `predictions.results.predictionHidden` to "Hidden until the match is in progress" / "Oculto hasta que el partido esté en juego" (also fixes a prior Spanish grammar slip).

This stays at the frontend display layer, consistent with how visibility is currently enforced.

## Testing

- `npm run lint` — clean; `npm run type-check` — no new errors (pre-existing `playwright.config.ts` module errors are unrelated).
- Manually: as a non-owner, a scheduled match shows the hidden label; flipping the match to `in_progress` in Studio reveals all predictions and shows it in the dashboard's Upcoming Matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)