### PR TITLE
feat(profile): default avatar initials when no picture is set

### DIFF
--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -14,10 +14,22 @@ const Avatar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElem
 Avatar.displayName = "Avatar";
 
 const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
-  ({ className, alt = "", ...props }, ref) => (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img ref={ref} alt={alt} className={cn("aspect-square h-full w-full", className)} {...props} />
-  )
+  ({ className, alt = "", src, ...props }, ref) => {
+    // Without a src there is no picture to show — let the fallback (initials)
+    // render instead of an empty/broken <img> overlaying it.
+    if (!src) return null;
+
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        ref={ref}
+        src={src}
+        alt={alt}
+        className={cn("absolute inset-0 aspect-square h-full w-full object-cover", className)}
+        {...props}
+      />
+    );
+  }
 );
 AvatarImage.displayName = "AvatarImage";
 
@@ -26,7 +38,7 @@ const AvatarFallback = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTM
     <div
       ref={ref}
       className={cn(
-        "flex h-full w-full items-center justify-center rounded-full bg-muted",
+        "flex h-full w-full items-center justify-center rounded-full bg-muted font-medium text-muted-foreground",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Users now get a default display picture — the first letter of their name, capitalized — whenever no avatar image is set, mirroring the team short-name fallback approach.

## Problem

The hand-rolled `Avatar` primitive in `components/ui/avatar.tsx` (not the Radix version) always rendered an `<img>` even with no `src`, sitting as a sibling to the fallback in the same flex row. A user with no `avatar_url` got an empty/clipped image circle instead of their initials — the default picture never appeared, even though the initials logic already existed (`getPublicUserInitials` → first letter capitalized).

## Fix

- `AvatarImage` returns `null` when there's no `src`, and overlays the circle absolutely (`absolute inset-0 … object-cover`) when present.
- `AvatarFallback` is the always-rendered base layer, so initials show through when no image exists. Added `font-medium text-muted-foreground` so the letter reads as an intentional avatar.

Because every avatar usage already passes initials to `AvatarFallback`, this single primitive fix lights up the default picture everywhere — nav menu, rankings, tournament dashboard, profile editor, and match prediction lists. Example: a user named "Fultbolmaster" with no photo now shows **F**.

No new dependencies, no schema or API changes — purely a presentational primitive fix.

## Testing

- `npm run type-check` passes (pre-existing `playwright.config.ts` errors unrelated).
- Dev server runs against local Supabase; app and auth endpoints return `HTTP 200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)