### PR TITLE
feat(rankings): add prediction breakdown leaderboard tab

### DIFF
--- a/app/(app)/(user)/[tournamentId]/rankings/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/page.tsx
@@ -1,7 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
-import { RankingsTable } from "@/components/rankings/rankings-table";
-import { RankingWithPublicUser } from "@/types/database";
+import { RankingsTabs } from "@/components/rankings/rankings-tabs";
+import { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
+import { getPublicUserDisplay } from "@/lib/utils/privacy";
 import { BackButton } from "@/components/layout/back-button";
 import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { getTranslations } from "next-intl/server";
@@ -40,6 +41,27 @@ export default async function RankingsPage({
     .eq("tournament_id", tournamentId)
     .order("rank", { ascending: true });
 
+  const { data: breakdownData } = await supabase
+    .from("tournament_prediction_breakdown")
+    .select(
+      `
+      *,
+      user:users(id, screen_name, avatar_url, created_at, updated_at)
+    `
+    )
+    .eq("tournament_id", tournamentId);
+
+  // Sort: most exact -> most goal-diff -> most winner -> alphabetical by display name
+  const breakdown = ((breakdownData || []) as BreakdownWithPublicUser[])
+    .slice()
+    .sort(
+      (a, b) =>
+        b.exact_count - a.exact_count ||
+        b.goal_diff_count - a.goal_diff_count ||
+        b.winner_count - a.winner_count ||
+        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
+    );
+
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">
       <TournamentBreadcrumbs
@@ -56,8 +78,9 @@ export default async function RankingsPage({
           <BackButton fallbackHref={`/${tournamentId}`} />
         </div>
       </div>
-      <RankingsTable
+      <RankingsTabs
         rankings={(rankings || []) as RankingWithPublicUser[]}
+        breakdown={breakdown}
         currentUserId={user?.id}
         tournamentId={tournamentId}
       />

--- a/components/rankings/breakdown-table.tsx
+++ b/components/rankings/breakdown-table.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { BreakdownWithPublicUser } from "@/types/database";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
+import { getPodiumStyle, getRankColor } from "@/components/rankings/podium";
+
+interface BreakdownTableProps {
+  breakdown: BreakdownWithPublicUser[];
+  currentUserId?: string;
+  tournamentId: string;
+}
+
+export function BreakdownTable({ breakdown, currentUserId, tournamentId }: BreakdownTableProps) {
+  const t = useTranslations("rankings");
+  const tCommon = useTranslations("common");
+  const router = useRouter();
+
+  if (breakdown.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">{t("breakdown.noData")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("breakdown.title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-xs uppercase tracking-wider text-muted-foreground">
+                <th scope="col" className="w-8 px-2 py-2 text-center font-medium">
+                  {tCommon("labels.rank")}
+                </th>
+                <th scope="col" className="px-2 py-2 text-left font-medium">
+                  {tCommon("labels.name")}
+                </th>
+                <th scope="col" className="px-2 py-2 text-center font-medium">
+                  {t("breakdown.exact")}
+                </th>
+                <th scope="col" className="px-2 py-2 text-center font-medium">
+                  {t("breakdown.goalDiff")}
+                </th>
+                <th scope="col" className="px-2 py-2 text-center font-medium">
+                  {t("breakdown.winner")}
+                </th>
+                <th scope="col" className="px-2 py-2 text-right font-medium">
+                  {tCommon("labels.points")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {breakdown.map((row, index) => {
+                const isCurrentUser = row.user_id === currentUserId;
+                const position = index + 1;
+                const href = `/${tournamentId}/rankings/${row.user_id}`;
+
+                return (
+                  <tr
+                    key={row.user_id}
+                    onClick={() => router.push(href)}
+                    className={`border-b last:border-b-0 cursor-pointer transition-colors ${getPodiumStyle(
+                      position
+                    )} ${
+                      isCurrentUser ? "ring-2 ring-inset ring-primary/30 bg-primary/10" : "hover:bg-muted"
+                    }`}
+                  >
+                    {/* Position */}
+                    <td className="w-8 px-2 py-3 text-center">
+                      <span className={`font-display text-xl font-bold ${getRankColor(position)}`}>
+                        {position}
+                      </span>
+                    </td>
+
+                    {/* Player */}
+                    <td className="px-2 py-3">
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-9 w-9">
+                          <AvatarImage src={row.user.avatar_url ?? undefined} />
+                          <AvatarFallback>{getPublicUserInitials(row.user)}</AvatarFallback>
+                        </Avatar>
+                        <div className="flex items-center gap-2">
+                          <Link
+                            href={href}
+                            onClick={(e) => e.stopPropagation()}
+                            className="font-medium hover:underline"
+                          >
+                            {getPublicUserDisplay(row.user)}
+                          </Link>
+                          {isCurrentUser && (
+                            <Badge variant="outline" className="hidden sm:inline-flex">
+                              {t("you")}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* Exact */}
+                    <td className="px-2 py-3 text-center font-display font-bold tabular-nums">
+                      {row.exact_count}
+                    </td>
+
+                    {/* Goal difference */}
+                    <td className="px-2 py-3 text-center font-display font-bold tabular-nums">
+                      {row.goal_diff_count}
+                    </td>
+
+                    {/* Winner */}
+                    <td className="px-2 py-3 text-center font-display font-bold tabular-nums">
+                      {row.winner_count}
+                    </td>
+
+                    {/* Points */}
+                    <td className="px-2 py-3 text-right">
+                      <Badge variant="secondary">
+                        <span className="font-display font-bold">{row.total_points}</span>
+                        <span className="ml-1">{tCommon("labels.pts")}</span>
+                      </Badge>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/rankings/podium.ts
+++ b/components/rankings/podium.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared podium styling helpers for the rankings leaderboard and breakdown tables.
+ */
+
+export function getPodiumStyle(rank: number): string {
+  if (rank === 1)
+    return "border-l-4 border-l-gold bg-gradient-to-r from-[hsl(var(--gold)/0.15)] to-transparent";
+  if (rank === 2)
+    return "border-l-4 border-l-silver bg-gradient-to-r from-[hsl(var(--silver)/0.1)] to-transparent";
+  if (rank === 3)
+    return "border-l-4 border-l-bronze bg-gradient-to-r from-[hsl(var(--bronze)/0.1)] to-transparent";
+  return "";
+}
+
+export function getRankColor(rank: number): string {
+  if (rank === 1) return "text-gold";
+  if (rank === 2) return "text-silver";
+  if (rank === 3) return "text-bronze";
+  return "text-muted-foreground";
+}

--- a/components/rankings/rankings-table.tsx
+++ b/components/rankings/rankings-table.tsx
@@ -6,29 +6,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
+import { getPodiumStyle, getRankColor } from "@/components/rankings/podium";
 import Link from "next/link";
 
 interface RankingsTableProps {
   rankings: RankingWithPublicUser[];
   currentUserId?: string;
   tournamentId: string;
-}
-
-function getPodiumStyle(rank: number): string {
-  if (rank === 1)
-    return "border-l-4 border-l-gold bg-gradient-to-r from-[hsl(var(--gold)/0.15)] to-transparent";
-  if (rank === 2)
-    return "border-l-4 border-l-silver bg-gradient-to-r from-[hsl(var(--silver)/0.1)] to-transparent";
-  if (rank === 3)
-    return "border-l-4 border-l-bronze bg-gradient-to-r from-[hsl(var(--bronze)/0.1)] to-transparent";
-  return "";
-}
-
-function getRankColor(rank: number): string {
-  if (rank === 1) return "text-gold";
-  if (rank === 2) return "text-silver";
-  if (rank === 3) return "text-bronze";
-  return "text-muted-foreground";
 }
 
 export function RankingsTable({ rankings, currentUserId, tournamentId }: RankingsTableProps) {

--- a/components/rankings/rankings-tabs.tsx
+++ b/components/rankings/rankings-tabs.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { RankingsTable } from "@/components/rankings/rankings-table";
+import { BreakdownTable } from "@/components/rankings/breakdown-table";
+import { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
+
+interface RankingsTabsProps {
+  rankings: RankingWithPublicUser[];
+  breakdown: BreakdownWithPublicUser[];
+  currentUserId?: string;
+  tournamentId: string;
+}
+
+export function RankingsTabs({
+  rankings,
+  breakdown,
+  currentUserId,
+  tournamentId,
+}: RankingsTabsProps) {
+  const t = useTranslations("rankings");
+
+  return (
+    <Tabs defaultValue="leaderboard">
+      <TabsList>
+        <TabsTrigger value="leaderboard">{t("breakdown.tabLeaderboard")}</TabsTrigger>
+        <TabsTrigger value="breakdown">{t("breakdown.tabBreakdown")}</TabsTrigger>
+      </TabsList>
+      <TabsContent value="leaderboard">
+        <RankingsTable
+          rankings={rankings}
+          currentUserId={currentUserId}
+          tournamentId={tournamentId}
+        />
+      </TabsContent>
+      <TabsContent value="breakdown">
+        <BreakdownTable
+          breakdown={breakdown}
+          currentUserId={currentUserId}
+          tournamentId={tournamentId}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/messages/en.json
+++ b/messages/en.json
@@ -547,6 +547,15 @@
     "empty": "No rankings available yet.",
     "noRankings": "No rankings available yet.",
     "you": "You",
+    "breakdown": {
+      "tabLeaderboard": "Leaderboard",
+      "tabBreakdown": "Breakdown",
+      "title": "Prediction breakdown",
+      "exact": "Exact",
+      "goalDiff": "Goal diff",
+      "winner": "Winner",
+      "noData": "No completed matches yet."
+    },
     "userPredictions": {
       "you": "You",
       "predictionsFor": "Predictions for {tournament}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -547,6 +547,15 @@
     "empty": "Aún no hay clasificaciones disponibles.",
     "noRankings": "Aún no hay clasificaciones disponibles.",
     "you": "Tú",
+    "breakdown": {
+      "tabLeaderboard": "Clasificación",
+      "tabBreakdown": "Desglose",
+      "title": "Desglose de pronósticos",
+      "exact": "Exactos",
+      "goalDiff": "Diferencia",
+      "winner": "Ganador",
+      "noData": "Aún no hay partidos finalizados."
+    },
     "userPredictions": {
       "you": "Tú",
       "predictionsFor": "pronósticos para {tournament}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-tabs": "^1.1.14",
         "@simplewebauthn/browser": "^13.2.2",
         "@simplewebauthn/server": "^13.2.2",
         "@supabase/ssr": "^0.8.0",
@@ -182,6 +183,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -587,6 +589,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -627,6 +630,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2636,6 +2640,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -3219,6 +3224,293 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.14.tgz",
+      "integrity": "sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz",
+      "integrity": "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3884,6 +4176,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
       "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.90.1",
         "@supabase/functions-js": "2.90.1",
@@ -4106,7 +4399,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4196,8 +4488,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4304,6 +4595,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4314,6 +4606,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4372,6 +4665,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -5021,6 +5315,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5561,6 +5856,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6124,7 +6420,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6176,8 +6471,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -6502,6 +6796,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6675,6 +6970,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8102,6 +8398,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8132,6 +8429,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8435,7 +8733,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9273,6 +9570,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9284,6 +9582,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9330,6 +9629,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9505,7 +9805,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9521,7 +9820,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9532,7 +9830,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9545,8 +9842,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
@@ -9624,6 +9920,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9633,6 +9930,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10840,6 +11138,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10961,6 +11260,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11090,6 +11390,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11279,6 +11580,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11372,6 +11674,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11385,6 +11688,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-tabs": "^1.1.14",
     "@simplewebauthn/browser": "^13.2.2",
     "@simplewebauthn/server": "^13.2.2",
     "@supabase/ssr": "^0.8.0",

--- a/supabase/migrations/20260611000000_add_prediction_breakdown_view.sql
+++ b/supabase/migrations/20260611000000_add_prediction_breakdown_view.sql
@@ -1,0 +1,59 @@
+-- ============================================================================
+-- Add Prediction Breakdown View
+-- ============================================================================
+-- Migration: 20260611000000_add_prediction_breakdown_view
+-- Created: 2026-06-11
+-- Description: Adds tournament_prediction_breakdown VIEW that counts, per user
+--              per tournament, how many predictions landed in each scoring
+--              category over completed matches:
+--                - exact_count     : exact score (3 base pts)
+--                - goal_diff_count : correct winner + correct goal diff (2 base pts)
+--                - winner_count    : correct winner only (1 base pt)
+--
+--              The category arithmetic below mirrors getBasePoints() in
+--              lib/utils/scoring.ts -- keep the two in lockstep. Mirrors the
+--              tournament_rankings view (security_invoker, tournament_participants
+--              join, active-user filter).
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.tournament_prediction_breakdown
+WITH (security_invoker = true) AS
+SELECT
+    p.user_id,
+    m.tournament_id,
+    u.screen_name,
+    u.avatar_url,
+    COUNT(*) FILTER (
+        WHERE p.predicted_home_score = m.home_score
+          AND p.predicted_away_score = m.away_score
+    ) AS exact_count,
+    COUNT(*) FILTER (
+        WHERE NOT (p.predicted_home_score = m.home_score AND p.predicted_away_score = m.away_score)
+          AND sign(p.predicted_home_score - p.predicted_away_score)
+                = sign(m.home_score - m.away_score)
+          AND abs(p.predicted_home_score - p.predicted_away_score)
+                = abs(m.home_score - m.away_score)
+    ) AS goal_diff_count,
+    COUNT(*) FILTER (
+        WHERE NOT (p.predicted_home_score = m.home_score AND p.predicted_away_score = m.away_score)
+          AND sign(p.predicted_home_score - p.predicted_away_score)
+                = sign(m.home_score - m.away_score)
+          AND abs(p.predicted_home_score - p.predicted_away_score)
+                <> abs(m.home_score - m.away_score)
+    ) AS winner_count,
+    COALESCE(SUM(p.points_earned), 0) AS total_points
+FROM public.predictions p
+JOIN public.matches m ON p.match_id = m.id
+JOIN public.users u ON p.user_id = u.id
+JOIN public.tournament_participants tp
+    ON tp.tournament_id = m.tournament_id
+    AND tp.user_id = p.user_id
+WHERE u.status = 'active'
+  AND m.status = 'completed'
+  AND m.home_score IS NOT NULL
+  AND m.away_score IS NOT NULL
+GROUP BY p.user_id, m.tournament_id, u.screen_name, u.avatar_url;
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================

--- a/types/database.ts
+++ b/types/database.ts
@@ -85,6 +85,20 @@ export interface TournamentRanking {
   // created_at and updated_at are not available
 }
 
+/**
+ * Per-user prediction breakdown for a tournament (computed view).
+ * Counts how many predictions landed in each scoring category over completed
+ * matches. Mirrors the getBasePoints() categories in lib/utils/scoring.ts.
+ */
+export interface TournamentPredictionBreakdown {
+  user_id: string;
+  tournament_id: string;
+  exact_count: number;
+  goal_diff_count: number;
+  winner_count: number;
+  total_points: number;
+}
+
 // Extended types with relations
 export interface MatchWithTeams extends Match {
   home_team: Team;
@@ -136,5 +150,12 @@ export type AdminUserView = PublicUserProfile & {
  * Ranking with public user data - used in tournament leaderboards
  */
 export type RankingWithPublicUser = TournamentRanking & {
+  user: PublicUserProfile;
+};
+
+/**
+ * Prediction breakdown with public user data - used in the breakdown leaderboard tab
+ */
+export type BreakdownWithPublicUser = TournamentPredictionBreakdown & {
   user: PublicUserProfile;
 };


### PR DESCRIPTION
## Context

The leaderboard previously showed only each player's **total points**, hiding _where_ those points come from. This adds a second **Breakdown** tab on the rankings page that splits each player's correct predictions into three buckets — **exact scores** (3 pt), **correct goal difference** (2 pt), and **correct winner only** (1 pt) — giving players visibility into their performance profile and a principled tiebreaker signal.

The breakdown is sorted by: most exact → most goal differences → most correct winners → alphabetical by display name. It also shows a position number and total points, with rows that behave like the main leaderboard (clickable to a player's predictions, current user highlighted, podium styling).

## Changes

- **DB**: new `tournament_prediction_breakdown` SQL view (`supabase/migrations/20260611000000_add_prediction_breakdown_view.sql`) mirroring `tournament_rankings` (security_invoker, `tournament_participants` join, active-user filter). Counts categories over completed matches; the SQL arithmetic is kept in lockstep with `getBasePoints()` in `lib/utils/scoring.ts`.
- **Types**: `TournamentPredictionBreakdown` + `BreakdownWithPublicUser`.
- **UI**:
  - `components/ui/tabs.tsx` — shadcn Tabs primitive (adds `@radix-ui/react-tabs`).
  - `components/rankings/podium.ts` — shared podium helpers extracted from `rankings-table`.
  - `components/rankings/breakdown-table.tsx` — semantic `<table>` with `<th scope>`, clickable rows, current-user highlight.
  - `components/rankings/rankings-tabs.tsx` — Leaderboard (default) + Breakdown tabs.
  - Page fetches the breakdown and sorts it `exact ↓ → goal-diff ↓ → winner ↓ → name ↑`.
- **i18n**: `rankings.breakdown` block in `messages/en.json` and `messages/es.json`.

## Verification

- `npm run type-check`, `npm run lint`, `npm run build` — all clean.
- `npm run supabase:reset` applies the migration; queried the view and hand-verified counts against seeded predictions match `getBasePoints()`.
- `npm test` — 182/182 pass.
- Manually confirmed in the running app: both tabs render, sort order and columns correct, current-user highlight and row navigation work.

No new API routes or middleware, so no co-located route tests are required per project conventions (additive: a SQL view + Server Component fetch + display components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)