### PR TITLE
fix(rankings): show all ranked players in prediction breakdown

### DIFF
--- a/components/rankings/breakdown-table.tsx
+++ b/components/rankings/breakdown-table.tsx
@@ -24,7 +24,7 @@ export function BreakdownTable({ breakdown, currentUserId, tournamentId }: Break
   if (breakdown.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-muted-foreground">{t("breakdown.noData")}</p>
+        <p className="text-muted-foreground">{t("noRankings")}</p>
       </div>
     );
   }

--- a/messages/en.json
+++ b/messages/en.json
@@ -553,8 +553,7 @@
       "title": "Prediction breakdown",
       "exact": "Exact",
       "goalDiff": "Goal diff",
-      "winner": "Winner",
-      "noData": "No completed matches yet."
+      "winner": "Winner"
     },
     "userPredictions": {
       "you": "You",

--- a/messages/es.json
+++ b/messages/es.json
@@ -553,8 +553,7 @@
       "title": "Desglose de pronósticos",
       "exact": "Exactos",
       "goalDiff": "Diferencia",
-      "winner": "Ganador",
-      "noData": "Aún no hay partidos finalizados."
+      "winner": "Ganador"
     },
     "userPredictions": {
       "you": "Tú",

--- a/supabase/migrations/20260611100000_fix_prediction_breakdown_view_player_set.sql
+++ b/supabase/migrations/20260611100000_fix_prediction_breakdown_view_player_set.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- Fix Prediction Breakdown View Player Set
+-- ============================================================================
+-- Migration: 20260611100000_fix_prediction_breakdown_view_player_set
+-- Created: 2026-06-11
+-- Description: The original tournament_prediction_breakdown view (migration
+--              20260611000000) filtered "m.status = 'completed'" in its WHERE
+--              clause. That dropped any player who had no prediction on a
+--              completed match, so a tournament with completed matches whose
+--              ranked players had only predicted not-yet-completed matches
+--              produced zero rows -- making the Breakdown tab look empty even
+--              though completed matches existed.
+--
+--              Fix: move the completed-match condition INSIDE each
+--              COUNT(...) FILTER. The row set now matches tournament_rankings:
+--              every active participant with at least one prediction appears,
+--              with zero category counts when they have no predictions on
+--              completed matches yet.
+--
+--              Category arithmetic still mirrors getBasePoints() in
+--              lib/utils/scoring.ts -- keep the two in lockstep.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.tournament_prediction_breakdown
+WITH (security_invoker = true) AS
+SELECT
+    p.user_id,
+    m.tournament_id,
+    u.screen_name,
+    u.avatar_url,
+    COUNT(*) FILTER (
+        WHERE m.status = 'completed'
+          AND m.home_score IS NOT NULL
+          AND m.away_score IS NOT NULL
+          AND p.predicted_home_score = m.home_score
+          AND p.predicted_away_score = m.away_score
+    ) AS exact_count,
+    COUNT(*) FILTER (
+        WHERE m.status = 'completed'
+          AND m.home_score IS NOT NULL
+          AND m.away_score IS NOT NULL
+          AND NOT (p.predicted_home_score = m.home_score AND p.predicted_away_score = m.away_score)
+          AND sign(p.predicted_home_score - p.predicted_away_score)
+                = sign(m.home_score - m.away_score)
+          AND abs(p.predicted_home_score - p.predicted_away_score)
+                = abs(m.home_score - m.away_score)
+    ) AS goal_diff_count,
+    COUNT(*) FILTER (
+        WHERE m.status = 'completed'
+          AND m.home_score IS NOT NULL
+          AND m.away_score IS NOT NULL
+          AND NOT (p.predicted_home_score = m.home_score AND p.predicted_away_score = m.away_score)
+          AND sign(p.predicted_home_score - p.predicted_away_score)
+                = sign(m.home_score - m.away_score)
+          AND abs(p.predicted_home_score - p.predicted_away_score)
+                <> abs(m.home_score - m.away_score)
+    ) AS winner_count,
+    COALESCE(SUM(p.points_earned), 0) AS total_points
+FROM public.predictions p
+JOIN public.matches m ON p.match_id = m.id
+JOIN public.users u ON p.user_id = u.id
+JOIN public.tournament_participants tp
+    ON tp.tournament_id = m.tournament_id
+    AND tp.user_id = p.user_id
+WHERE u.status = 'active'
+GROUP BY p.user_id, m.tournament_id, u.screen_name, u.avatar_url;
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Problem

The Breakdown tab (added in #76) showed **"no completed matches yet"** even when the tournament had completed matches.

## Root cause

`tournament_prediction_breakdown` filtered `m.status = 'completed'` in its **`WHERE`** clause. That dropped any player who had no prediction on a completed match. So when a tournament had completed matches but its ranked players had only predicted not-yet-completed matches, the view returned **zero rows** — and the table fell back to its empty state, even though completed matches existed. The `tournament_rankings` view doesn't filter by match status, which is why the Leaderboard tab still listed players — the two views diverged.

## Fix

- **New migration** `20260611100000_fix_prediction_breakdown_view_player_set.sql` recreates the view (`CREATE OR REPLACE`) with the completed-match condition moved **inside each `COUNT(...) FILTER`**. The row set now matches `tournament_rankings`: every active participant with at least one prediction appears, showing **zero counts** when they have no completed-match predictions yet. The original migration (`20260611000000`, already merged in #76) is left untouched.
- Replace the now-inaccurate `breakdown.noData` ("No completed matches yet.") empty-state with the shared `noRankings` string — the table is only empty when there are no ranked players at all. Removed the unused key from `en.json`/`es.json`.

## Verification

- DB reset applies both migrations in order (original → corrective); final view is correct.
- **Regression**: normal seed data still shows all 3 players with correct counts (1/0/0, 0/1/0, 0/1/0).
- **Reproduction** (transaction, rolled back): a completed match nobody predicted while players' predictions were on non-completed matches. Old behavior → 0 breakdown rows (the bug); fixed view → all 3 players shown with zero counts, matching the leaderboard.
- `type-check`, `lint`, `build` clean; `npm test` 182/182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)