### PR TITLE
fix(rankings): sort leaderboard by points then name for consistency

### DIFF
--- a/app/(app)/(user)/[tournamentId]/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { TournamentDashboard } from "@/components/tournaments/tournament-dashboard";
+import { getPublicUserDisplay } from "@/lib/utils/privacy";
 import { notFound } from "next/navigation";
 
 export default async function TournamentPage({
@@ -50,6 +51,15 @@ export default async function TournamentPage({
     .eq("tournament_id", tournamentId)
     .order("rank", { ascending: true });
 
+  // Sort: highest points -> alphabetical by display name (deterministic tie-break)
+  const sortedRankings = (rankings || [])
+    .slice()
+    .sort(
+      (a, b) =>
+        b.total_points - a.total_points ||
+        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
+    );
+
   // Get user stats
   const userRanking = rankings?.find((r) => r.user_id === user?.id);
 
@@ -88,7 +98,7 @@ export default async function TournamentPage({
       <TournamentDashboard
         tournament={tournament}
         matches={matches || []}
-        rankings={rankings || []}
+        rankings={sortedRankings}
         currentUserId={user?.id ?? ""}
         userStats={userStats}
         tournamentStats={tournamentStats}

--- a/app/(app)/(user)/[tournamentId]/rankings/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/page.tsx
@@ -41,6 +41,15 @@ export default async function RankingsPage({
     .eq("tournament_id", tournamentId)
     .order("rank", { ascending: true });
 
+  // Sort: highest points -> alphabetical by display name (deterministic tie-break)
+  const sortedRankings = ((rankings || []) as RankingWithPublicUser[])
+    .slice()
+    .sort(
+      (a, b) =>
+        b.total_points - a.total_points ||
+        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
+    );
+
   const { data: breakdownData } = await supabase
     .from("tournament_prediction_breakdown")
     .select(
@@ -79,7 +88,7 @@ export default async function RankingsPage({
         </div>
       </div>
       <RankingsTabs
-        rankings={(rankings || []) as RankingWithPublicUser[]}
+        rankings={sortedRankings}
         breakdown={breakdown}
         currentUserId={user?.id}
         tournamentId={tournamentId}


### PR DESCRIPTION
## Context

The main leaderboard (Leaderboard tab and the dashboard top-10 preview) was ordered solely by the `tournament_rankings` view's `rank` column, which is computed with `RANK() OVER (... ORDER BY total_points DESC)` — **no tiebreaker**. Players with equal total points appeared in non-deterministic order that could differ between the rankings page and the dashboard preview, and shuffle between page loads.

## Change

Apply a stable secondary sort — **points descending, then display name ascending** — wherever `tournament_rankings` rows are rendered, reusing the existing `getPublicUserDisplay` helper and mirroring the breakdown tab's existing tie-break.

- `app/(app)/(user)/[tournamentId]/rankings/page.tsx` — sort rankings before passing to `RankingsTabs`
- `app/(app)/(user)/[tournamentId]/page.tsx` — same sort on the rankings feeding the dashboard preview

The database `rank` value is untouched, so tied players still correctly share a rank number — only the display order within a tie is made deterministic. No SQL migration needed.

## Verification

- `npm run type-check` and ESLint pass clean
- Manual: with two players tied on points, they now appear alphabetically with the same rank, consistently on both the rankings page and dashboard preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)