### PR TITLE
feat(rankings): auto-fit dashboard leaderboard to available height

### DIFF
--- a/components/tournaments/tournament-dashboard.tsx
+++ b/components/tournaments/tournament-dashboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Tournament, MatchWithTeams, RankingWithPublicUser } from "@/types/database";
@@ -26,6 +27,14 @@ interface TournamentDashboardProps {
     participantCount: number;
   };
 }
+
+// Auto-fit leaderboard sizing. ROW_GAP matches the `space-y-2` (0.5rem) between
+// rows; ROW_HEIGHT is the fallback row height (≈ 48px content) used before a row
+// is measured. MIN_ROWS keeps the list from collapsing when the card is short.
+const ROW_GAP = 8;
+const ROW_HEIGHT = 48;
+const MIN_ROWS = 5;
+const DEFAULT_ROWS = 10;
 
 const statusColors: Record<string, string> = {
   upcoming: "bg-info",
@@ -58,7 +67,31 @@ export function TournamentDashboard({
     .filter((m) => m.status === "completed")
     .slice(-5)
     .reverse();
-  const topRankings = rankings.slice(0, 10);
+  // Render as many ranking rows as fit the leaderboard card's available height,
+  // which the grid stretches to match the taller "Upcoming Matches" sibling.
+  const leaderboardRef = useRef<HTMLDivElement>(null);
+  const [fitCount, setFitCount] = useState(DEFAULT_ROWS);
+
+  useLayoutEffect(() => {
+    const container = leaderboardRef.current;
+    if (!container) return;
+
+    const recompute = () => {
+      const height = container.clientHeight;
+      if (height <= 0) return;
+      const firstRow = container.firstElementChild as HTMLElement | null;
+      const rowHeight = firstRow?.offsetHeight || ROW_HEIGHT;
+      const count = Math.floor((height + ROW_GAP) / (rowHeight + ROW_GAP));
+      setFitCount(Math.max(MIN_ROWS, count));
+    };
+
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [rankings.length]);
+
+  const topRankings = rankings.slice(0, fitCount);
 
   return (
     <div className="space-y-8 animate-fade-in">
@@ -148,7 +181,7 @@ export function TournamentDashboard({
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Leaderboard */}
-        <Card>
+        <Card className="flex flex-col h-full">
           <CardHeader>
             <div className="flex justify-between items-center">
               <CardTitle className="flex items-center gap-2">
@@ -162,11 +195,11 @@ export function TournamentDashboard({
               </Link>
             </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex flex-col flex-1 min-h-0">
             {topRankings.length === 0 ? (
               <p className="text-muted-foreground text-center py-8">{t("dashboard.noRankings")}</p>
             ) : (
-              <div className="space-y-2">
+              <div ref={leaderboardRef} className="flex-1 min-h-0 space-y-2 overflow-hidden">
                 {topRankings.map((ranking, index) => {
                   const isCurrentUser = ranking.user_id === currentUserId;
                   const podiumBorder =


### PR DESCRIPTION
## Summary

The tournament dashboard leaderboard was hard-capped at 10 rows (`rankings.slice(0, 10)`), leaving visible empty space at the bottom of the card. Because the leaderboard sits in a 2-column CSS grid next to "Upcoming Matches", the grid stretches both cells to equal height — when the matches card is taller, the leaderboard left a gap.

This change measures the leaderboard card's available height at runtime and renders **as many ranking rows as physically fit**, eliminating the empty space and adapting to the viewport.

## Changes

All confined to `components/tournaments/tournament-dashboard.tsx`:

- **Auto-fit count** — replaced the static `slice(0, 10)` with a `fitCount` computed in a `useLayoutEffect` + `ResizeObserver`. It reads the rows container height, measures the first row's actual height (fallback `48px`), and computes `floor((height + gap) / (rowHeight + gap))`, clamped to a `MIN_ROWS` floor of 5. Recomputes on resize; disconnects on cleanup. Defaults to 10 pre-measurement to avoid a hydration flash.
- **Fill layout** — leaderboard `Card` → `flex flex-col h-full`, `CardContent` → `flex flex-col flex-1 min-h-0`, rows wrapper → `flex-1 min-h-0 space-y-2 overflow-hidden` so the list fills the stretched cell, is measurable, and never spills a partial row.

Since the leaderboard only ever renders as many rows as fit, it never exceeds the cell — no resize feedback loop. No data-fetch change: the page already loads the full sorted ranking set.

## Testing

- `npm run type-check` passes.
- Verified locally against the running dev server (local Supabase): leaderboard fills the card to match the "Upcoming Matches" height and re-fits on window resize; empty state and few-player cases render without overflow or console errors.

No new API route/middleware, so no co-located test is required per `.claude/rules/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)