### PR TITLE
feat(insights): tournament-level insights page

### DIFF
--- a/app/(app)/(user)/[tournamentId]/insights/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/insights/page.tsx
@@ -1,0 +1,136 @@
+import { createClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
+import { TournamentInsights } from "@/components/tournaments/tournament-insights";
+import type {
+  MatchWithTeams,
+  Prediction,
+  RankingWithPublicUser,
+  BreakdownWithPublicUser,
+} from "@/types/database";
+
+export default async function InsightsPage({
+  params,
+}: {
+  params: Promise<{ tournamentId: string }>;
+}) {
+  const t = await getTranslations("insights");
+  const { tournamentId } = await params;
+  const supabase = await createClient();
+
+  const { data: tournament } = await supabase
+    .from("tournaments")
+    .select("*")
+    .eq("id", tournamentId)
+    .single();
+
+  if (!tournament) {
+    notFound();
+  }
+
+  // All matches with teams (totals need every match; stats use completed ones).
+  const { data: matchesData } = await supabase
+    .from("matches")
+    .select(
+      `
+      *,
+      home_team:teams!matches_home_team_id_fkey(*),
+      away_team:teams!matches_away_team_id_fkey(*)
+    `
+    )
+    .eq("tournament_id", tournamentId)
+    .order("match_date", { ascending: true });
+
+  const matches = (matchesData ?? []) as MatchWithTeams[];
+  const matchIds = matches.map((m) => m.id);
+
+  // Every prediction across the tournament (predicted scores + awarded points).
+  let predictions: Pick<
+    Prediction,
+    "match_id" | "predicted_home_score" | "predicted_away_score" | "points_earned"
+  >[] = [];
+  if (matchIds.length > 0) {
+    const { data: predictionData } = await supabase
+      .from("predictions")
+      .select("match_id, predicted_home_score, predicted_away_score, points_earned")
+      .in("match_id", matchIds);
+    predictions = predictionData ?? [];
+  }
+
+  // Group predictions by match for the completed-match stat groups.
+  const byMatch = new Map<
+    string,
+    { predicted_home_score: number; predicted_away_score: number }[]
+  >();
+  for (const p of predictions) {
+    const list = byMatch.get(p.match_id) ?? [];
+    list.push({
+      predicted_home_score: p.predicted_home_score,
+      predicted_away_score: p.predicted_away_score,
+    });
+    byMatch.set(p.match_id, list);
+  }
+
+  const completed = matches
+    .filter((m) => m.status === "completed" && m.home_score !== null && m.away_score !== null)
+    .map((match) => ({ match, predictions: byMatch.get(match.id) ?? [] }));
+
+  const totalPointsAwarded = predictions.reduce((sum, p) => sum + (p.points_earned ?? 0), 0);
+
+  const { count: participantCount } = await supabase
+    .from("tournament_participants")
+    .select("*", { count: "exact", head: true })
+    .eq("tournament_id", tournamentId);
+
+  const { data: rankingsData } = await supabase
+    .from("tournament_rankings")
+    .select(
+      `
+      *,
+      user:users(id, screen_name, avatar_url, created_at, updated_at)
+    `
+    )
+    .eq("tournament_id", tournamentId)
+    .order("rank", { ascending: true });
+
+  const { data: breakdownData } = await supabase
+    .from("tournament_prediction_breakdown")
+    .select(
+      `
+      *,
+      user:users(id, screen_name, avatar_url, created_at, updated_at)
+    `
+    )
+    .eq("tournament_id", tournamentId);
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-4xl">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament.name}
+        items={[{ label: t("breadcrumb") }]}
+      />
+      <div className="mb-8 flex justify-between items-center">
+        <div>
+          <h1 className="text-4xl font-bold mb-2">{t("title")}</h1>
+          <p className="text-muted-foreground">{t("subtitle")}</p>
+        </div>
+        <BackButton fallbackHref={`/${tournamentId}`} />
+      </div>
+      <TournamentInsights
+        tournamentId={tournamentId}
+        completed={completed}
+        totals={{
+          participantCount: participantCount ?? 0,
+          totalMatches: matches.length,
+          predictionsSubmitted: predictions.length,
+          totalPointsAwarded,
+        }}
+        rankings={(rankingsData ?? []) as RankingWithPublicUser[]}
+        breakdown={(breakdownData ?? []) as BreakdownWithPublicUser[]}
+      />
+    </div>
+  );
+}

--- a/components/matches/match-statistics-card.tsx
+++ b/components/matches/match-statistics-card.tsx
@@ -3,7 +3,6 @@
 import { MatchWithTeams, Prediction } from "@/types/database";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Badge } from "@/components/ui/badge";
 import {
   computeOutcomeOdds,
   computeScoreDistribution,
@@ -14,6 +13,8 @@ import {
   distributePercentages,
   type AccuracyBreakdown,
 } from "@/lib/utils/match-stats";
+import { ShareBreakdown, type ShareItem } from "@/components/stats/share-breakdown";
+import { DistributionView } from "@/components/stats/distribution-view";
 import { BarChart3, CheckCircle2, XCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -129,62 +130,7 @@ export function MatchStatisticsCard({ match, predictions }: MatchStatisticsCardP
   );
 }
 
-/* --------------------- Shared stacked-bar breakdown --------------------- */
-
-interface ShareItem {
-  key: string;
-  /** Legend label for this segment. */
-  label: string;
-  /** Tailwind background class for the bar/swatch color. */
-  colorClass: string;
-  /** Integer percentage of the total (segments should sum to 100). */
-  percentage: number;
-  /** Raw number of predictions in this segment. */
-  count: number;
-}
-
-/**
- * A stacked proportion bar followed by a legend showing each segment's label,
- * percentage, and prediction count. Shared by the Odds and Accuracy views.
- */
-function ShareBreakdown({
-  items,
-  predictionsLabel,
-}: {
-  items: ShareItem[];
-  predictionsLabel: (n: number) => string;
-}) {
-  return (
-    <div className="space-y-4">
-      {/* Stacked bar */}
-      <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted" aria-hidden="true">
-        {items.map((item) =>
-          item.percentage > 0 ? (
-            <div
-              key={item.key}
-              className={item.colorClass}
-              style={{ width: `${item.percentage}%` }}
-            />
-          ) : null
-        )}
-      </div>
-
-      {/* Legend */}
-      <ul className="space-y-2">
-        {items.map((item) => (
-          <li key={item.key} className="flex items-center gap-3">
-            <span className={`h-3 w-3 shrink-0 rounded-sm ${item.colorClass}`} aria-hidden="true" />
-            <span className="flex-1 truncate">{item.label}</span>
-            <span className="font-display font-bold tabular-nums">{item.percentage}%</span>
-            <span className="w-28 text-right text-sm text-muted-foreground tabular-nums">
-              {predictionsLabel(item.count)}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
+/* --------------------- Accuracy view segments --------------------- */
 
 /** Build the Accuracy view segments, with percentages that sum to exactly 100. */
 function buildAccuracyItems(
@@ -224,215 +170,6 @@ function buildAccuracyItems(
       count: accuracy.miss,
     },
   ];
-}
-
-/* --------------------------- Score distribution -------------------------- */
-
-// Distinct slice colors (defined in globals.css for both light & dark themes).
-const SLICE_COLOR_VARS = [
-  "--chart-cat-1",
-  "--chart-cat-2",
-  "--chart-cat-3",
-  "--chart-cat-4",
-  "--chart-cat-5",
-  "--chart-cat-6",
-];
-const OTHER_COLOR_VAR = "--chart-cat-other";
-
-/** Show at most this many distinct slices; the remainder is grouped into "Other". */
-const MAX_SLICES = 6;
-
-interface DistributionSegment {
-  label: string;
-  count: number;
-  percentage: number;
-  isMostCommon: boolean;
-  isOther: boolean;
-  color: string;
-}
-
-function DistributionView({
-  distribution,
-  total,
-  headers,
-  mostCommonLabel,
-  otherLabel,
-  chartLabel,
-  centerLabel,
-}: {
-  distribution: ReturnType<typeof computeScoreDistribution>;
-  total: number;
-  headers: { scoreline: string; count: string; share: string };
-  mostCommonLabel: string;
-  otherLabel: string;
-  chartLabel: string;
-  centerLabel: string;
-}) {
-  // Group the long tail so the donut stays readable.
-  const segments: DistributionSegment[] = [];
-  if (distribution.length <= MAX_SLICES) {
-    distribution.forEach((e, i) => {
-      segments.push({
-        label: e.label,
-        count: e.count,
-        percentage: e.percentage,
-        isMostCommon: e.isMostCommon,
-        isOther: false,
-        color: `hsl(var(${SLICE_COLOR_VARS[i]}))`,
-      });
-    });
-  } else {
-    const head = distribution.slice(0, MAX_SLICES - 1);
-    const tail = distribution.slice(MAX_SLICES - 1);
-    head.forEach((e, i) => {
-      segments.push({
-        label: e.label,
-        count: e.count,
-        percentage: e.percentage,
-        isMostCommon: e.isMostCommon,
-        isOther: false,
-        color: `hsl(var(${SLICE_COLOR_VARS[i]}))`,
-      });
-    });
-    const tailCount = tail.reduce((sum, e) => sum + e.count, 0);
-    segments.push({
-      label: otherLabel,
-      count: tailCount,
-      percentage: total > 0 ? Math.round((tailCount / total) * 100) : 0,
-      isMostCommon: false,
-      isOther: true,
-      color: `hsl(var(${OTHER_COLOR_VAR}))`,
-    });
-  }
-
-  return (
-    <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center sm:gap-8">
-      <DonutChart
-        segments={segments}
-        total={total}
-        centerLabel={centerLabel}
-        ariaLabel={chartLabel}
-      />
-
-      {/* Accessible data table doubling as the chart legend. */}
-      <table className="w-full text-sm sm:flex-1">
-        <thead>
-          <tr className="border-b text-muted-foreground">
-            <th scope="col" className="py-2 text-left font-medium">
-              {headers.scoreline}
-            </th>
-            <th scope="col" className="py-2 text-right font-medium">
-              {headers.count}
-            </th>
-            <th scope="col" className="py-2 pr-1 text-right font-medium">
-              {headers.share}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {segments.map((seg) => (
-            <tr key={seg.label} className="border-b last:border-0">
-              <th scope="row" className="py-2 text-left font-normal">
-                <span className="flex items-center gap-2">
-                  <span
-                    className="h-3 w-3 shrink-0 rounded-sm"
-                    style={{ backgroundColor: seg.color }}
-                    aria-hidden="true"
-                  />
-                  <span
-                    className={
-                      seg.isOther ? "text-muted-foreground" : "font-display font-bold tabular-nums"
-                    }
-                  >
-                    {seg.label}
-                  </span>
-                  {seg.isMostCommon && (
-                    <Badge variant="secondary" className="text-xs">
-                      {mostCommonLabel}
-                    </Badge>
-                  )}
-                </span>
-              </th>
-              <td className="py-2 text-right tabular-nums">{seg.count}</td>
-              <td className="py-2 pr-1 text-right tabular-nums text-muted-foreground">
-                {seg.percentage}%
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function DonutChart({
-  segments,
-  total,
-  centerLabel,
-  ariaLabel,
-}: {
-  segments: DistributionSegment[];
-  total: number;
-  centerLabel: string;
-  ariaLabel: string;
-}) {
-  const size = 168;
-  const stroke = 30;
-  const radius = (size - stroke) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-  // Hairline gap (in user units) between adjacent slices for legibility.
-  const gap = segments.length > 1 ? 2 : 0;
-
-  let offset = 0;
-
-  return (
-    <div className="relative shrink-0" style={{ width: size, height: size }}>
-      <svg
-        viewBox={`0 0 ${size} ${size}`}
-        width={size}
-        height={size}
-        role="img"
-        aria-label={ariaLabel}
-        // Rotate so the first slice starts at 12 o'clock.
-        style={{ transform: "rotate(-90deg)" }}
-      >
-        {/* Track */}
-        <circle
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke="hsl(var(--muted))"
-          strokeWidth={stroke}
-        />
-        {segments.map((seg) => {
-          const fraction = total > 0 ? seg.count / total : 0;
-          const dash = Math.max(fraction * circumference - gap, 0);
-          const circle = (
-            <circle
-              key={seg.label}
-              cx={center}
-              cy={center}
-              r={radius}
-              fill="none"
-              stroke={seg.color}
-              strokeWidth={stroke}
-              strokeDasharray={`${dash} ${circumference - dash}`}
-              strokeDashoffset={-offset}
-            />
-          );
-          offset += fraction * circumference;
-          return circle;
-        })}
-      </svg>
-      {/* Center readout */}
-      <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="font-display text-3xl font-bold tabular-nums">{total}</span>
-        <span className="text-xs text-muted-foreground">{centerLabel}</span>
-      </div>
-    </div>
-  );
 }
 
 /* ----------------------------- Crowd consensus --------------------------- */

--- a/components/stats/distribution-view.tsx
+++ b/components/stats/distribution-view.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { DonutChart } from "@/components/stats/donut-chart";
 import type { ScoreDistributionEntry } from "@/lib/utils/match-stats";
 
 // Distinct slice colors (defined in globals.css for both light & dark themes).
@@ -139,76 +140,6 @@ export function DistributionView({
           ))}
         </tbody>
       </table>
-    </div>
-  );
-}
-
-function DonutChart({
-  segments,
-  total,
-  centerLabel,
-  ariaLabel,
-}: {
-  segments: DistributionSegment[];
-  total: number;
-  centerLabel: string;
-  ariaLabel: string;
-}) {
-  const size = 168;
-  const stroke = 30;
-  const radius = (size - stroke) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-  // Hairline gap (in user units) between adjacent slices for legibility.
-  const gap = segments.length > 1 ? 2 : 0;
-
-  let offset = 0;
-
-  return (
-    <div className="relative shrink-0" style={{ width: size, height: size }}>
-      <svg
-        viewBox={`0 0 ${size} ${size}`}
-        width={size}
-        height={size}
-        role="img"
-        aria-label={ariaLabel}
-        // Rotate so the first slice starts at 12 o'clock.
-        style={{ transform: "rotate(-90deg)" }}
-      >
-        {/* Track */}
-        <circle
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke="hsl(var(--muted))"
-          strokeWidth={stroke}
-        />
-        {segments.map((seg) => {
-          const fraction = total > 0 ? seg.count / total : 0;
-          const dash = Math.max(fraction * circumference - gap, 0);
-          const circle = (
-            <circle
-              key={seg.label}
-              cx={center}
-              cy={center}
-              r={radius}
-              fill="none"
-              stroke={seg.color}
-              strokeWidth={stroke}
-              strokeDasharray={`${dash} ${circumference - dash}`}
-              strokeDashoffset={-offset}
-            />
-          );
-          offset += fraction * circumference;
-          return circle;
-        })}
-      </svg>
-      {/* Center readout */}
-      <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="font-display text-3xl font-bold tabular-nums">{total}</span>
-        <span className="text-xs text-muted-foreground">{centerLabel}</span>
-      </div>
     </div>
   );
 }

--- a/components/stats/distribution-view.tsx
+++ b/components/stats/distribution-view.tsx
@@ -1,0 +1,214 @@
+import { Badge } from "@/components/ui/badge";
+import type { ScoreDistributionEntry } from "@/lib/utils/match-stats";
+
+// Distinct slice colors (defined in globals.css for both light & dark themes).
+const SLICE_COLOR_VARS = [
+  "--chart-cat-1",
+  "--chart-cat-2",
+  "--chart-cat-3",
+  "--chart-cat-4",
+  "--chart-cat-5",
+  "--chart-cat-6",
+];
+const OTHER_COLOR_VAR = "--chart-cat-other";
+
+/** Show at most this many distinct slices; the remainder is grouped into "Other". */
+const MAX_SLICES = 6;
+
+interface DistributionSegment {
+  label: string;
+  count: number;
+  percentage: number;
+  isMostCommon: boolean;
+  isOther: boolean;
+  color: string;
+}
+
+/**
+ * A donut chart plus an accessible data table (doubling as the chart legend) for a
+ * scoreline distribution. The long tail beyond MAX_SLICES is grouped into "Other".
+ * Shared by the match statistics card and the tournament insights page.
+ */
+export function DistributionView({
+  distribution,
+  total,
+  headers,
+  mostCommonLabel,
+  otherLabel,
+  chartLabel,
+  centerLabel,
+}: {
+  distribution: ScoreDistributionEntry[];
+  total: number;
+  headers: { scoreline: string; count: string; share: string };
+  mostCommonLabel: string;
+  otherLabel: string;
+  chartLabel: string;
+  centerLabel: string;
+}) {
+  // Group the long tail so the donut stays readable.
+  const segments: DistributionSegment[] = [];
+  if (distribution.length <= MAX_SLICES) {
+    distribution.forEach((e, i) => {
+      segments.push({
+        label: e.label,
+        count: e.count,
+        percentage: e.percentage,
+        isMostCommon: e.isMostCommon,
+        isOther: false,
+        color: `hsl(var(${SLICE_COLOR_VARS[i]}))`,
+      });
+    });
+  } else {
+    const head = distribution.slice(0, MAX_SLICES - 1);
+    const tail = distribution.slice(MAX_SLICES - 1);
+    head.forEach((e, i) => {
+      segments.push({
+        label: e.label,
+        count: e.count,
+        percentage: e.percentage,
+        isMostCommon: e.isMostCommon,
+        isOther: false,
+        color: `hsl(var(${SLICE_COLOR_VARS[i]}))`,
+      });
+    });
+    const tailCount = tail.reduce((sum, e) => sum + e.count, 0);
+    segments.push({
+      label: otherLabel,
+      count: tailCount,
+      percentage: total > 0 ? Math.round((tailCount / total) * 100) : 0,
+      isMostCommon: false,
+      isOther: true,
+      color: `hsl(var(${OTHER_COLOR_VAR}))`,
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center sm:gap-8">
+      <DonutChart
+        segments={segments}
+        total={total}
+        centerLabel={centerLabel}
+        ariaLabel={chartLabel}
+      />
+
+      {/* Accessible data table doubling as the chart legend. */}
+      <table className="w-full text-sm sm:flex-1">
+        <thead>
+          <tr className="border-b text-muted-foreground">
+            <th scope="col" className="py-2 text-left font-medium">
+              {headers.scoreline}
+            </th>
+            <th scope="col" className="py-2 text-right font-medium">
+              {headers.count}
+            </th>
+            <th scope="col" className="py-2 pr-1 text-right font-medium">
+              {headers.share}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {segments.map((seg) => (
+            <tr key={seg.label} className="border-b last:border-0">
+              <th scope="row" className="py-2 text-left font-normal">
+                <span className="flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 shrink-0 rounded-sm"
+                    style={{ backgroundColor: seg.color }}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className={
+                      seg.isOther ? "text-muted-foreground" : "font-display font-bold tabular-nums"
+                    }
+                  >
+                    {seg.label}
+                  </span>
+                  {seg.isMostCommon && (
+                    <Badge variant="secondary" className="text-xs">
+                      {mostCommonLabel}
+                    </Badge>
+                  )}
+                </span>
+              </th>
+              <td className="py-2 text-right tabular-nums">{seg.count}</td>
+              <td className="py-2 pr-1 text-right tabular-nums text-muted-foreground">
+                {seg.percentage}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DonutChart({
+  segments,
+  total,
+  centerLabel,
+  ariaLabel,
+}: {
+  segments: DistributionSegment[];
+  total: number;
+  centerLabel: string;
+  ariaLabel: string;
+}) {
+  const size = 168;
+  const stroke = 30;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+  // Hairline gap (in user units) between adjacent slices for legibility.
+  const gap = segments.length > 1 ? 2 : 0;
+
+  let offset = 0;
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+        role="img"
+        aria-label={ariaLabel}
+        // Rotate so the first slice starts at 12 o'clock.
+        style={{ transform: "rotate(-90deg)" }}
+      >
+        {/* Track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="hsl(var(--muted))"
+          strokeWidth={stroke}
+        />
+        {segments.map((seg) => {
+          const fraction = total > 0 ? seg.count / total : 0;
+          const dash = Math.max(fraction * circumference - gap, 0);
+          const circle = (
+            <circle
+              key={seg.label}
+              cx={center}
+              cy={center}
+              r={radius}
+              fill="none"
+              stroke={seg.color}
+              strokeWidth={stroke}
+              strokeDasharray={`${dash} ${circumference - dash}`}
+              strokeDashoffset={-offset}
+            />
+          );
+          offset += fraction * circumference;
+          return circle;
+        })}
+      </svg>
+      {/* Center readout */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="font-display text-3xl font-bold tabular-nums">{total}</span>
+        <span className="text-xs text-muted-foreground">{centerLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/stats/donut-chart.tsx
+++ b/components/stats/donut-chart.tsx
@@ -1,0 +1,84 @@
+export interface DonutSegment {
+  /** Used as the React key; not rendered. */
+  label: string;
+  count: number;
+  /** Any CSS color value, e.g. `hsl(var(--success))`. */
+  color: string;
+}
+
+/**
+ * A donut chart rendered from segment counts, with a center readout of the total.
+ * Colors are supplied per segment so callers control the palette. Shared by the
+ * scoreline distribution view and the tournament outcome breakdowns.
+ */
+export function DonutChart({
+  segments,
+  total,
+  centerLabel,
+  ariaLabel,
+  size = 168,
+  stroke = 30,
+}: {
+  segments: DonutSegment[];
+  total: number;
+  centerLabel: string;
+  ariaLabel: string;
+  size?: number;
+  stroke?: number;
+}) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+  // Hairline gap (in user units) between adjacent slices for legibility.
+  const gap = segments.filter((s) => s.count > 0).length > 1 ? 2 : 0;
+
+  let offset = 0;
+
+  return (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+        role="img"
+        aria-label={ariaLabel}
+        // Rotate so the first slice starts at 12 o'clock.
+        style={{ transform: "rotate(-90deg)" }}
+      >
+        {/* Track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="hsl(var(--muted))"
+          strokeWidth={stroke}
+        />
+        {segments.map((seg) => {
+          const fraction = total > 0 ? seg.count / total : 0;
+          const dash = Math.max(fraction * circumference - gap, 0);
+          const circle = (
+            <circle
+              key={seg.label}
+              cx={center}
+              cy={center}
+              r={radius}
+              fill="none"
+              stroke={seg.color}
+              strokeWidth={stroke}
+              strokeDasharray={`${dash} ${circumference - dash}`}
+              strokeDashoffset={-offset}
+            />
+          );
+          offset += fraction * circumference;
+          return circle;
+        })}
+      </svg>
+      {/* Center readout */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="font-display text-3xl font-bold tabular-nums">{total}</span>
+        <span className="text-xs text-muted-foreground">{centerLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/stats/share-breakdown.tsx
+++ b/components/stats/share-breakdown.tsx
@@ -1,0 +1,55 @@
+export interface ShareItem {
+  key: string;
+  /** Legend label for this segment. */
+  label: string;
+  /** Tailwind background class for the bar/swatch color. */
+  colorClass: string;
+  /** Integer percentage of the total (segments should sum to 100). */
+  percentage: number;
+  /** Raw number of predictions in this segment. */
+  count: number;
+}
+
+/**
+ * A stacked proportion bar followed by a legend showing each segment's label,
+ * percentage, and prediction count. Shared by the match Odds/Accuracy views and
+ * the tournament insights breakdowns.
+ */
+export function ShareBreakdown({
+  items,
+  predictionsLabel,
+}: {
+  items: ShareItem[];
+  predictionsLabel: (n: number) => string;
+}) {
+  return (
+    <div className="space-y-4">
+      {/* Stacked bar */}
+      <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted" aria-hidden="true">
+        {items.map((item) =>
+          item.percentage > 0 ? (
+            <div
+              key={item.key}
+              className={item.colorClass}
+              style={{ width: `${item.percentage}%` }}
+            />
+          ) : null
+        )}
+      </div>
+
+      {/* Legend */}
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.key} className="flex items-center gap-3">
+            <span className={`h-3 w-3 shrink-0 rounded-sm ${item.colorClass}`} aria-hidden="true" />
+            <span className="flex-1 truncate">{item.label}</span>
+            <span className="font-display font-bold tabular-nums">{item.percentage}%</span>
+            <span className="w-28 text-right text-sm text-muted-foreground tabular-nums">
+              {predictionsLabel(item.count)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/tournaments/tournament-dashboard.tsx
+++ b/components/tournaments/tournament-dashboard.tsx
@@ -11,7 +11,7 @@ import { MatchCard } from "@/components/matches/match-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatLocalDate } from "@/lib/utils/date";
 import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
-import { Calendar, Trophy, UserCircle, Target } from "lucide-react";
+import { Calendar, Trophy, UserCircle, Target, BarChart3 } from "lucide-react";
 
 interface TournamentDashboardProps {
   tournament: Tournament;
@@ -151,6 +151,12 @@ export function TournamentDashboard({
           <Button variant="outline" size="lg">
             <Calendar className="h-4 w-4 mr-2" />
             {t("dashboard.allMatches")}
+          </Button>
+        </Link>
+        <Link href={`/${tournament.id}/insights`}>
+          <Button variant="outline" size="lg">
+            <BarChart3 className="h-4 w-4 mr-2" aria-hidden="true" />
+            {t("dashboard.insights")}
           </Button>
         </Link>
       </div>

--- a/components/tournaments/tournament-insights.tsx
+++ b/components/tournaments/tournament-insights.tsx
@@ -2,12 +2,7 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import {
-  MatchWithTeams,
-  RankingWithPublicUser,
-  BreakdownWithPublicUser,
-  PublicUserProfile,
-} from "@/types/database";
+import { MatchWithTeams, RankingWithPublicUser, BreakdownWithPublicUser } from "@/types/database";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -25,7 +20,7 @@ import {
   type MatchStatGroup,
 } from "@/lib/utils/tournament-stats";
 import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
-import { BarChart3, Crown, Target, Percent, ListChecks, CheckCircle2 } from "lucide-react";
+import { BarChart3, Crown, TrendingDown, Eye, Coins, CheckCircle2, Info } from "lucide-react";
 
 type Group = MatchStatGroup<MatchWithTeams>;
 
@@ -56,6 +51,7 @@ export function TournamentInsights({
   if (completed.length === 0) {
     return (
       <div className="space-y-8">
+        <ScopeNote t={t} />
         <KpiRow kpis={kpis} t={t} />
         <Card>
           <CardContent className="py-12 text-center">
@@ -73,6 +69,7 @@ export function TournamentInsights({
 
   return (
     <div className="space-y-8">
+      <ScopeNote t={t} />
       <KpiRow kpis={kpis} t={t} />
 
       <Card>
@@ -105,6 +102,17 @@ export function TournamentInsights({
 }
 
 type T = ReturnType<typeof useTranslations>;
+
+/* -------------------------------- Scope note ------------------------------ */
+
+function ScopeNote({ t }: { t: T }) {
+  return (
+    <p className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Info className="h-4 w-4 shrink-0" aria-hidden="true" />
+      {t("scopeNote")}
+    </p>
+  );
+}
 
 /* --------------------------------- KPI row -------------------------------- */
 
@@ -472,15 +480,23 @@ function AwardsTab({
           </span>
           <div className="min-w-0 flex-1">
             <p className="text-sm text-muted-foreground">{a.title}</p>
-            <div className="mt-1 flex items-center gap-2">
-              <Avatar className="h-6 w-6">
-                <AvatarImage src={a.avatarUrl ?? undefined} />
-                <AvatarFallback>{a.initials}</AvatarFallback>
-              </Avatar>
-              <span className="truncate font-medium">{a.name}</span>
-            </div>
+            {a.player ? (
+              <div className="mt-1 flex items-center gap-2">
+                <Avatar className="h-6 w-6">
+                  <AvatarImage src={a.player.avatarUrl ?? undefined} />
+                  <AvatarFallback>{a.player.initials}</AvatarFallback>
+                </Avatar>
+                <span className="truncate font-medium">{a.player.name}</span>
+              </div>
+            ) : (
+              <p className="mt-1 font-medium italic text-muted-foreground">
+                {t("awards.stillAtPlay")}
+              </p>
+            )}
           </div>
-          <span className="shrink-0 font-display text-xl font-bold tabular-nums">{a.value}</span>
+          {a.player && a.value && (
+            <span className="shrink-0 font-display text-xl font-bold tabular-nums">{a.value}</span>
+          )}
         </div>
       ))}
     </div>
@@ -491,10 +507,10 @@ interface Award {
   key: string;
   icon: React.ReactNode;
   title: string;
-  name: string;
-  initials: string;
-  avatarUrl: string | null;
-  value: string;
+  /** Resolved recipient, or null when the standing is tied / undecided. */
+  player: { name: string; initials: string; avatarUrl: string | null } | null;
+  /** Stat shown on the right; hidden when the award is undecided. */
+  value?: string;
 }
 
 function computeAwards(
@@ -502,104 +518,85 @@ function computeAwards(
   breakdown: BreakdownWithPublicUser[],
   t: T
 ): Award[] {
-  const awards: Award[] = [];
-
-  const pickRanking = (
-    pool: RankingWithPublicUser[],
-    score: (r: RankingWithPublicUser) => number
-  ) =>
-    pool.length === 0
-      ? null
-      : pool.reduce((best, r) => (score(r) > score(best) ? r : best), pool[0]);
-
-  const pickBreakdown = (
-    pool: BreakdownWithPublicUser[],
-    score: (r: BreakdownWithPublicUser) => number
-  ) =>
-    pool.length === 0
-      ? null
-      : pool.reduce((best, r) => (score(r) > score(best) ? r : best), pool[0]);
-
-  const toAward = (
-    key: string,
-    icon: React.ReactNode,
-    title: string,
-    user: PublicUserProfile,
-    value: string
-  ): Award => ({
-    key,
-    icon,
-    title,
-    name: getPublicUserDisplay(user),
-    initials: getPublicUserInitials(user),
-    avatarUrl: user.avatar_url,
-    value,
+  // Join each ranked player with their prediction breakdown counts.
+  const countsByUser = new Map(breakdown.map((b) => [b.user_id, b]));
+  const players = rankings.map((r) => {
+    const b = countsByUser.get(r.user_id);
+    const exact = b?.exact_count ?? 0;
+    const goalDiff = b?.goal_diff_count ?? 0;
+    const winner = b?.winner_count ?? 0;
+    return {
+      user: r.user,
+      points: r.total_points,
+      exact,
+      goalDiff,
+      winner,
+      correct: exact + goalDiff + winner,
+      avgPoints: r.predictions_count > 0 ? r.total_points / r.predictions_count : 0,
+    };
   });
 
-  // Leader — highest total points.
-  const leader = pickRanking(rankings, (r) => r.total_points);
-  if (leader && leader.total_points > 0) {
-    awards.push(
-      toAward(
-        "leader",
-        <Crown className="h-5 w-5" aria-hidden="true" />,
-        t("awards.leader"),
-        leader.user,
-        t("awards.pointsValue", { points: leader.total_points })
-      )
-    );
-  }
+  if (players.length === 0) return [];
 
-  // Specialist — most exact scorelines.
-  const specialist = pickBreakdown(breakdown, (r) => r.exact_count);
-  if (specialist && specialist.exact_count > 0) {
-    awards.push(
-      toAward(
-        "specialist",
-        <Target className="h-5 w-5" aria-hidden="true" />,
-        t("awards.mostExact"),
-        specialist.user,
-        t("awards.exactValue", { count: specialist.exact_count })
-      )
-    );
-  }
+  type P = (typeof players)[number];
 
-  // Sharpshooter — highest hit rate (points-earning predictions / predictions made).
-  const countsByUser = new Map(breakdown.map((b) => [b.user_id, b]));
-  let sharp: { user: RankingWithPublicUser["user"]; rate: number } | null = null;
-  for (const r of rankings) {
-    if (r.predictions_count <= 0) continue;
-    const b = countsByUser.get(r.user_id);
-    if (!b) continue;
-    const hits = b.exact_count + b.goal_diff_count + b.winner_count;
-    const rate = hits / r.predictions_count;
-    if (!sharp || rate > sharp.rate) sharp = { user: r.user, rate };
-  }
-  if (sharp && sharp.rate > 0) {
-    awards.push(
-      toAward(
-        "sharpshooter",
-        <Percent className="h-5 w-5" aria-hidden="true" />,
-        t("awards.highestAccuracy"),
-        sharp.user,
-        `${Math.round(sharp.rate * 100)}%`
-      )
-    );
-  }
+  // Leaderboard order: points, then exact, then winner+difference, then winner.
+  const byStanding = (a: P, b: P) =>
+    b.points - a.points || b.exact - a.exact || b.goalDiff - a.goalDiff || b.winner - a.winner;
 
-  // Most active — most predictions submitted.
-  const active = pickRanking(rankings, (r) => r.predictions_count);
-  if (active && active.predictions_count > 0) {
-    awards.push(
-      toAward(
-        "active",
-        <ListChecks className="h-5 w-5" aria-hidden="true" />,
-        t("awards.mostPredictions"),
-        active.user,
-        String(active.predictions_count)
-      )
-    );
-  }
+  // The unique extreme under cmp, or null when the top two are perfectly tied.
+  const pickUnique = (cmp: (a: P, b: P) => number): P | null => {
+    const sorted = [...players].sort(cmp);
+    if (sorted.length > 1 && cmp(sorted[0], sorted[1]) === 0) return null;
+    return sorted[0];
+  };
 
-  return awards;
+  const toPlayer = (p: P | null) =>
+    p
+      ? {
+          name: getPublicUserDisplay(p.user),
+          initials: getPublicUserInitials(p.user),
+          avatarUrl: p.user.avatar_url,
+        }
+      : null;
+
+  const round1 = (n: number) => Math.round(n * 10) / 10;
+
+  const leader = pickUnique(byStanding);
+  const bottom = pickUnique((a, b) => byStanding(b, a)); // exact opposite of the leader
+  const clairvoyant = pickUnique((a, b) => b.correct - a.correct);
+  const highEarner = pickUnique((a, b) => b.avgPoints - a.avgPoints);
+
+  return [
+    {
+      key: "leader",
+      icon: <Crown className="h-5 w-5" aria-hidden="true" />,
+      title: t("awards.leader"),
+      player: toPlayer(leader),
+      value: leader ? t("awards.pointsValue", { points: leader.points }) : undefined,
+    },
+    {
+      key: "bottom",
+      icon: <TrendingDown className="h-5 w-5" aria-hidden="true" />,
+      title: t("awards.bottom"),
+      player: toPlayer(bottom),
+      value: bottom ? t("awards.pointsValue", { points: bottom.points }) : undefined,
+    },
+    {
+      key: "clairvoyant",
+      icon: <Eye className="h-5 w-5" aria-hidden="true" />,
+      title: t("awards.clairvoyant"),
+      player: toPlayer(clairvoyant),
+      value: clairvoyant ? t("awards.correctValue", { count: clairvoyant.correct }) : undefined,
+    },
+    {
+      key: "highEarner",
+      icon: <Coins className="h-5 w-5" aria-hidden="true" />,
+      title: t("awards.highEarner"),
+      player: toPlayer(highEarner),
+      value: highEarner
+        ? t("awards.avgValue", { points: round1(highEarner.avgPoints) })
+        : undefined,
+    },
+  ];
 }

--- a/components/tournaments/tournament-insights.tsx
+++ b/components/tournaments/tournament-insights.tsx
@@ -1,0 +1,559 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import {
+  MatchWithTeams,
+  RankingWithPublicUser,
+  BreakdownWithPublicUser,
+  PublicUserProfile,
+} from "@/types/database";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ShareBreakdown, type ShareItem } from "@/components/stats/share-breakdown";
+import { DistributionView } from "@/components/stats/distribution-view";
+import { distributePercentages, type Outcome } from "@/lib/utils/match-stats";
+import {
+  computeOverviewKpis,
+  computeTournamentAccuracy,
+  computeCrowdCalledRate,
+  computeOutcomeBias,
+  computeMatchSuperlatives,
+  type MatchStatGroup,
+} from "@/lib/utils/tournament-stats";
+import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
+import { BarChart3, Crown, Target, Percent, ListChecks, CheckCircle2 } from "lucide-react";
+
+type Group = MatchStatGroup<MatchWithTeams>;
+
+interface TournamentInsightsProps {
+  tournamentId: string;
+  completed: Group[];
+  totals: {
+    participantCount: number;
+    totalMatches: number;
+    predictionsSubmitted: number;
+    totalPointsAwarded: number;
+  };
+  rankings: RankingWithPublicUser[];
+  breakdown: BreakdownWithPublicUser[];
+}
+
+export function TournamentInsights({
+  tournamentId,
+  completed,
+  totals,
+  rankings,
+  breakdown,
+}: TournamentInsightsProps) {
+  const t = useTranslations("insights");
+
+  const kpis = computeOverviewKpis({ ...totals, completed });
+
+  if (completed.length === 0) {
+    return (
+      <div className="space-y-8">
+        <KpiRow kpis={kpis} t={t} />
+        <Card>
+          <CardContent className="py-12 text-center">
+            <BarChart3
+              className="mx-auto mb-4 h-10 w-10 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <p className="font-medium">{t("empty.title")}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{t("empty.description")}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <KpiRow kpis={kpis} t={t} />
+
+      <Card>
+        <CardContent className="pt-6">
+          <Tabs defaultValue="accuracy">
+            <TabsList className="flex-wrap h-auto">
+              <TabsTrigger value="accuracy">{t("tabs.accuracy")}</TabsTrigger>
+              <TabsTrigger value="results">{t("tabs.results")}</TabsTrigger>
+              <TabsTrigger value="matches">{t("tabs.matches")}</TabsTrigger>
+              <TabsTrigger value="awards">{t("tabs.awards")}</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="accuracy" className="pt-6">
+              <AccuracyTab completed={completed} t={t} />
+            </TabsContent>
+            <TabsContent value="results" className="pt-6">
+              <ResultsTab completed={completed} t={t} />
+            </TabsContent>
+            <TabsContent value="matches" className="pt-6">
+              <MatchesTab completed={completed} tournamentId={tournamentId} t={t} />
+            </TabsContent>
+            <TabsContent value="awards" className="pt-6">
+              <AwardsTab rankings={rankings} breakdown={breakdown} t={t} />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+type T = ReturnType<typeof useTranslations>;
+
+/* --------------------------------- KPI row -------------------------------- */
+
+function KpiRow({ kpis, t }: { kpis: ReturnType<typeof computeOverviewKpis>; t: T }) {
+  const cells: { label: string; value: string }[] = [
+    { label: t("kpi.participants"), value: String(kpis.participantCount) },
+    { label: t("kpi.predictions"), value: String(kpis.predictionsSubmitted) },
+    {
+      label: t("kpi.matchesScored"),
+      value: `${kpis.completedMatches}/${kpis.totalMatches}`,
+    },
+    { label: t("kpi.totalPoints"), value: String(kpis.totalPointsAwarded) },
+    { label: t("kpi.avgPoints"), value: String(kpis.avgPointsPerPrediction) },
+    { label: t("kpi.exactRate"), value: `${kpis.exactRate}%` },
+  ];
+
+  return (
+    <Card className="bg-gradient-to-r from-primary/15 via-primary/10 to-accent/5 border-primary/20">
+      <CardContent className="pt-6">
+        <dl className="grid grid-cols-2 gap-4 text-center sm:grid-cols-3 lg:grid-cols-6">
+          {cells.map((cell) => (
+            <div key={cell.label}>
+              <dd className="font-display text-3xl font-bold tabular-nums">{cell.value}</dd>
+              <dt className="text-sm text-muted-foreground">{cell.label}</dt>
+            </div>
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ------------------------------- Accuracy tab ----------------------------- */
+
+function AccuracyTab({ completed, t }: { completed: Group[]; t: T }) {
+  const accuracy = computeTournamentAccuracy(completed);
+  const crowd = computeCrowdCalledRate(completed);
+
+  const counts = [accuracy.exact, accuracy.winnerDiff, accuracy.winnerOnly, accuracy.miss];
+  const [exactPct, winnerDiffPct, winnerOnlyPct, missPct] = distributePercentages(counts);
+  const items: ShareItem[] = [
+    {
+      key: "exact",
+      label: t("accuracy.exact"),
+      colorClass: "bg-success",
+      percentage: exactPct,
+      count: accuracy.exact,
+    },
+    {
+      key: "winnerDiff",
+      label: t("accuracy.winnerDiff"),
+      colorClass: "bg-info",
+      percentage: winnerDiffPct,
+      count: accuracy.winnerDiff,
+    },
+    {
+      key: "winnerOnly",
+      label: t("accuracy.winnerOnly"),
+      colorClass: "bg-warning",
+      percentage: winnerOnlyPct,
+      count: accuracy.winnerOnly,
+    },
+    {
+      key: "miss",
+      label: t("accuracy.miss"),
+      colorClass: "bg-muted-foreground",
+      percentage: missPct,
+      count: accuracy.miss,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <ShareBreakdown items={items} predictionsLabel={(n) => t("predictions", { count: n })} />
+
+      <div
+        role="status"
+        className="flex items-center gap-3 rounded-lg border border-success/30 bg-success/10 p-4 text-success"
+      >
+        <CheckCircle2 className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <p className="text-sm font-medium">
+          {t("accuracy.crowdCalled", {
+            percentage: crowd.percentage,
+            called: crowd.called,
+            total: crowd.total,
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------- Results tab ----------------------------- */
+
+const OUTCOME_COLORS: Record<Outcome, string> = {
+  home: "bg-success",
+  draw: "bg-muted-foreground",
+  away: "bg-accent",
+};
+
+function ResultsTab({ completed, t }: { completed: Group[]; t: T }) {
+  const bias = computeOutcomeBias(completed);
+
+  const outcomeItems = (
+    counts: Record<Outcome, number>,
+    percentages: Record<Outcome, number>
+  ): ShareItem[] =>
+    (["home", "draw", "away"] as Outcome[]).map((o) => ({
+      key: o,
+      label: t(`results.${o}`),
+      colorClass: OUTCOME_COLORS[o],
+      percentage: percentages[o],
+      count: counts[o],
+    }));
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <h3 className="font-display text-lg font-bold">{t("results.actualTitle")}</h3>
+        <ShareBreakdown
+          items={outcomeItems(bias.actual.counts, bias.actual.percentages)}
+          predictionsLabel={(n) => t("matchesCount", { count: n })}
+        />
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="font-display text-lg font-bold">{t("results.predictedTitle")}</h3>
+        <ShareBreakdown
+          items={outcomeItems(bias.predicted.counts, bias.predicted.percentages)}
+          predictionsLabel={(n) => t("predictions", { count: n })}
+        />
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="font-display text-lg font-bold">{t("results.avgGoalsTitle")}</h3>
+        <div className="grid grid-cols-3 gap-4 rounded-lg border bg-muted/30 p-6 text-center">
+          <AvgGoalCell
+            label={t("results.goalsHome")}
+            predicted={bias.avgGoals.predictedHome}
+            actual={bias.avgGoals.actualHome}
+            t={t}
+          />
+          <AvgGoalCell
+            label={t("results.goalsAway")}
+            predicted={bias.avgGoals.predictedAway}
+            actual={bias.avgGoals.actualAway}
+            t={t}
+          />
+          <AvgGoalCell
+            label={t("results.goalsTotal")}
+            predicted={bias.avgGoals.predictedTotal}
+            actual={bias.avgGoals.actualTotal}
+            t={t}
+          />
+        </div>
+      </section>
+
+      {bias.scorelines.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="font-display text-lg font-bold">{t("results.scorelinesTitle")}</h3>
+          <DistributionView
+            distribution={bias.scorelines}
+            total={bias.actual.total}
+            headers={{
+              scoreline: t("results.scoreline"),
+              count: t("results.count"),
+              share: t("results.share"),
+            }}
+            mostCommonLabel={t("results.mostCommon")}
+            otherLabel={t("results.other")}
+            chartLabel={t("results.chartLabel")}
+            centerLabel={t("results.totalShort")}
+          />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function AvgGoalCell({
+  label,
+  predicted,
+  actual,
+  t,
+}: {
+  label: string;
+  predicted: number;
+  actual: number;
+  t: T;
+}) {
+  return (
+    <div>
+      <p className="text-sm font-medium text-muted-foreground">{label}</p>
+      <p className="mt-1 font-display text-2xl font-bold tabular-nums">{actual}</p>
+      <p className="text-xs text-muted-foreground">{t("results.actual")}</p>
+      <p className="mt-1 text-sm tabular-nums text-muted-foreground">
+        {t("results.predicted")}: {predicted}
+      </p>
+    </div>
+  );
+}
+
+/* -------------------------------- Matches tab ----------------------------- */
+
+function MatchesTab({
+  completed,
+  tournamentId,
+  t,
+}: {
+  completed: Group[];
+  tournamentId: string;
+  t: T;
+}) {
+  const { hardest, bestCalled, upsets } = computeMatchSuperlatives(completed);
+
+  const matchLabel = (m: MatchWithTeams) =>
+    `${m.home_team.short_name} ${m.home_score}–${m.away_score} ${m.away_team.short_name}`;
+
+  return (
+    <div className="space-y-8">
+      <MatchList title={t("matches.upsetsTitle")}>
+        {upsets.length === 0 ? (
+          <EmptyRow label={t("matches.none")} />
+        ) : (
+          upsets.map((u) => {
+            const favored =
+              u.consensusOutcome === "home"
+                ? u.match.home_team.short_name
+                : u.consensusOutcome === "away"
+                  ? u.match.away_team.short_name
+                  : t("results.draw");
+            return (
+              <MatchRow key={u.match.id} href={`/${tournamentId}/matches/${u.match.id}`}>
+                <span className="flex-1 truncate font-medium">{matchLabel(u.match)}</span>
+                <Badge variant="secondary" className="shrink-0">
+                  {t("matches.crowdFavored", { team: favored, percentage: u.consensusPercentage })}
+                </Badge>
+              </MatchRow>
+            );
+          })
+        )}
+      </MatchList>
+
+      <MatchList title={t("matches.hardestTitle")}>
+        {hardest.map((m) => (
+          <MatchRow key={m.match.id} href={`/${tournamentId}/matches/${m.match.id}`}>
+            <span className="flex-1 truncate font-medium">{matchLabel(m.match)}</span>
+            <Badge variant="secondary" className="shrink-0">
+              {t("matches.avgPointsLabel", { points: m.avgPoints })}
+            </Badge>
+          </MatchRow>
+        ))}
+      </MatchList>
+
+      <MatchList title={t("matches.bestCalledTitle")}>
+        {bestCalled.map((m) => (
+          <MatchRow key={m.match.id} href={`/${tournamentId}/matches/${m.match.id}`}>
+            <span className="flex-1 truncate font-medium">{matchLabel(m.match)}</span>
+            <Badge variant="secondary" className="shrink-0">
+              {t("matches.avgPointsLabel", { points: m.avgPoints })}
+            </Badge>
+          </MatchRow>
+        ))}
+      </MatchList>
+    </div>
+  );
+}
+
+function MatchList({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h3 className="font-display text-lg font-bold">{title}</h3>
+      <ul className="space-y-2">{children}</ul>
+    </section>
+  );
+}
+
+function MatchRow({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className="flex items-center gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50"
+      >
+        {children}
+      </Link>
+    </li>
+  );
+}
+
+function EmptyRow({ label }: { label: string }) {
+  return (
+    <li className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">{label}</li>
+  );
+}
+
+/* --------------------------------- Awards tab ----------------------------- */
+
+function AwardsTab({
+  rankings,
+  breakdown,
+  t,
+}: {
+  rankings: RankingWithPublicUser[];
+  breakdown: BreakdownWithPublicUser[];
+  t: T;
+}) {
+  const awards = computeAwards(rankings, breakdown, t);
+
+  if (awards.length === 0) {
+    return <p className="py-6 text-center text-sm text-muted-foreground">{t("matches.none")}</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {awards.map((a) => (
+        <div key={a.key} className="flex items-center gap-4 rounded-lg border p-4">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            {a.icon}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm text-muted-foreground">{a.title}</p>
+            <div className="mt-1 flex items-center gap-2">
+              <Avatar className="h-6 w-6">
+                <AvatarImage src={a.avatarUrl ?? undefined} />
+                <AvatarFallback>{a.initials}</AvatarFallback>
+              </Avatar>
+              <span className="truncate font-medium">{a.name}</span>
+            </div>
+          </div>
+          <span className="shrink-0 font-display text-xl font-bold tabular-nums">{a.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface Award {
+  key: string;
+  icon: React.ReactNode;
+  title: string;
+  name: string;
+  initials: string;
+  avatarUrl: string | null;
+  value: string;
+}
+
+function computeAwards(
+  rankings: RankingWithPublicUser[],
+  breakdown: BreakdownWithPublicUser[],
+  t: T
+): Award[] {
+  const awards: Award[] = [];
+
+  const pickRanking = (
+    pool: RankingWithPublicUser[],
+    score: (r: RankingWithPublicUser) => number
+  ) =>
+    pool.length === 0
+      ? null
+      : pool.reduce((best, r) => (score(r) > score(best) ? r : best), pool[0]);
+
+  const pickBreakdown = (
+    pool: BreakdownWithPublicUser[],
+    score: (r: BreakdownWithPublicUser) => number
+  ) =>
+    pool.length === 0
+      ? null
+      : pool.reduce((best, r) => (score(r) > score(best) ? r : best), pool[0]);
+
+  const toAward = (
+    key: string,
+    icon: React.ReactNode,
+    title: string,
+    user: PublicUserProfile,
+    value: string
+  ): Award => ({
+    key,
+    icon,
+    title,
+    name: getPublicUserDisplay(user),
+    initials: getPublicUserInitials(user),
+    avatarUrl: user.avatar_url,
+    value,
+  });
+
+  // Leader — highest total points.
+  const leader = pickRanking(rankings, (r) => r.total_points);
+  if (leader && leader.total_points > 0) {
+    awards.push(
+      toAward(
+        "leader",
+        <Crown className="h-5 w-5" aria-hidden="true" />,
+        t("awards.leader"),
+        leader.user,
+        t("awards.pointsValue", { points: leader.total_points })
+      )
+    );
+  }
+
+  // Specialist — most exact scorelines.
+  const specialist = pickBreakdown(breakdown, (r) => r.exact_count);
+  if (specialist && specialist.exact_count > 0) {
+    awards.push(
+      toAward(
+        "specialist",
+        <Target className="h-5 w-5" aria-hidden="true" />,
+        t("awards.mostExact"),
+        specialist.user,
+        t("awards.exactValue", { count: specialist.exact_count })
+      )
+    );
+  }
+
+  // Sharpshooter — highest hit rate (points-earning predictions / predictions made).
+  const countsByUser = new Map(breakdown.map((b) => [b.user_id, b]));
+  let sharp: { user: RankingWithPublicUser["user"]; rate: number } | null = null;
+  for (const r of rankings) {
+    if (r.predictions_count <= 0) continue;
+    const b = countsByUser.get(r.user_id);
+    if (!b) continue;
+    const hits = b.exact_count + b.goal_diff_count + b.winner_count;
+    const rate = hits / r.predictions_count;
+    if (!sharp || rate > sharp.rate) sharp = { user: r.user, rate };
+  }
+  if (sharp && sharp.rate > 0) {
+    awards.push(
+      toAward(
+        "sharpshooter",
+        <Percent className="h-5 w-5" aria-hidden="true" />,
+        t("awards.highestAccuracy"),
+        sharp.user,
+        `${Math.round(sharp.rate * 100)}%`
+      )
+    );
+  }
+
+  // Most active — most predictions submitted.
+  const active = pickRanking(rankings, (r) => r.predictions_count);
+  if (active && active.predictions_count > 0) {
+    awards.push(
+      toAward(
+        "active",
+        <ListChecks className="h-5 w-5" aria-hidden="true" />,
+        t("awards.mostPredictions"),
+        active.user,
+        String(active.predictions_count)
+      )
+    );
+  }
+
+  return awards;
+}

--- a/components/tournaments/tournament-insights.tsx
+++ b/components/tournaments/tournament-insights.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ShareBreakdown, type ShareItem } from "@/components/stats/share-breakdown";
 import { DistributionView } from "@/components/stats/distribution-view";
+import { DonutChart, type DonutSegment } from "@/components/stats/donut-chart";
 import { distributePercentages, type Outcome } from "@/lib/utils/match-stats";
 import {
   computeOverviewKpis,
@@ -198,43 +199,88 @@ function AccuracyTab({ completed, t }: { completed: Group[]; t: T }) {
 
 /* -------------------------------- Results tab ----------------------------- */
 
+// Consistent home/draw/away colors, shared by both donuts and the legend.
+const OUTCOMES: Outcome[] = ["home", "draw", "away"];
 const OUTCOME_COLORS: Record<Outcome, string> = {
-  home: "bg-success",
-  draw: "bg-muted-foreground",
-  away: "bg-accent",
+  home: "hsl(var(--success))",
+  draw: "hsl(var(--muted-foreground))",
+  away: "hsl(var(--accent))",
 };
 
 function ResultsTab({ completed, t }: { completed: Group[]; t: T }) {
   const bias = computeOutcomeBias(completed);
 
-  const outcomeItems = (
-    counts: Record<Outcome, number>,
-    percentages: Record<Outcome, number>
-  ): ShareItem[] =>
-    (["home", "draw", "away"] as Outcome[]).map((o) => ({
-      key: o,
-      label: t(`results.${o}`),
-      colorClass: OUTCOME_COLORS[o],
-      percentage: percentages[o],
-      count: counts[o],
-    }));
+  const donutSegments = (counts: Record<Outcome, number>): DonutSegment[] =>
+    OUTCOMES.map((o) => ({ label: o, count: counts[o], color: OUTCOME_COLORS[o] }));
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <h3 className="font-display text-lg font-bold">{t("results.actualTitle")}</h3>
-        <ShareBreakdown
-          items={outcomeItems(bias.actual.counts, bias.actual.percentages)}
-          predictionsLabel={(n) => t("matchesCount", { count: n })}
-        />
-      </section>
+      <section className="space-y-4">
+        <h3 className="font-display text-lg font-bold">{t("results.outcomesTitle")}</h3>
 
-      <section className="space-y-3">
-        <h3 className="font-display text-lg font-bold">{t("results.predictedTitle")}</h3>
-        <ShareBreakdown
-          items={outcomeItems(bias.predicted.counts, bias.predicted.percentages)}
-          predictionsLabel={(n) => t("predictions", { count: n })}
-        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <figure className="flex flex-col items-center gap-2">
+            <figcaption className="text-sm font-medium text-muted-foreground">
+              {t("results.actualTitle")}
+            </figcaption>
+            <DonutChart
+              segments={donutSegments(bias.actual.counts)}
+              total={bias.actual.total}
+              centerLabel={t("results.totalShort")}
+              ariaLabel={t("results.actualTitle")}
+            />
+          </figure>
+          <figure className="flex flex-col items-center gap-2">
+            <figcaption className="text-sm font-medium text-muted-foreground">
+              {t("results.predictedTitle")}
+            </figcaption>
+            <DonutChart
+              segments={donutSegments(bias.predicted.counts)}
+              total={bias.predicted.total}
+              centerLabel={t("results.predictionsShort")}
+              ariaLabel={t("results.predictedTitle")}
+            />
+          </figure>
+        </div>
+
+        {/* Single shared legend, doubling as an actual-vs-predicted comparison. */}
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-muted-foreground">
+              <th scope="col" className="py-2 text-left font-medium">
+                {t("results.outcome")}
+              </th>
+              <th scope="col" className="py-2 text-right font-medium">
+                {t("results.actual")}
+              </th>
+              <th scope="col" className="py-2 pr-1 text-right font-medium">
+                {t("results.predicted")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {OUTCOMES.map((o) => (
+              <tr key={o} className="border-b last:border-0">
+                <th scope="row" className="py-2 text-left font-normal">
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="h-3 w-3 shrink-0 rounded-sm"
+                      style={{ backgroundColor: OUTCOME_COLORS[o] }}
+                      aria-hidden="true"
+                    />
+                    {t(`results.${o}`)}
+                  </span>
+                </th>
+                <td className="py-2 text-right tabular-nums">
+                  {bias.actual.counts[o]} ({bias.actual.percentages[o]}%)
+                </td>
+                <td className="py-2 pr-1 text-right tabular-nums">
+                  {bias.predicted.counts[o]} ({bias.predicted.percentages[o]}%)
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </section>
 
       <section className="space-y-3">

--- a/lib/utils/__tests__/tournament-stats.test.ts
+++ b/lib/utils/__tests__/tournament-stats.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeOverviewKpis,
+  computeTournamentAccuracy,
+  computeCrowdCalledRate,
+  computeOutcomeBias,
+  computeMatchSuperlatives,
+  type MatchStatGroup,
+} from "../tournament-stats";
+import type { PredictionLike } from "../match-stats";
+
+function p(home: number, away: number): PredictionLike {
+  return { predicted_home_score: home, predicted_away_score: away };
+}
+
+/** A minimal completed-match group with an id for superlative assertions. */
+function group(
+  id: string,
+  home: number | null,
+  away: number | null,
+  predictions: PredictionLike[]
+): MatchStatGroup<{ id: string; home_score: number | null; away_score: number | null }> {
+  return { match: { id, home_score: home, away_score: away }, predictions };
+}
+
+describe("computeOverviewKpis", () => {
+  it("returns zeros when nothing has happened", () => {
+    const kpis = computeOverviewKpis({
+      participantCount: 0,
+      totalMatches: 0,
+      predictionsSubmitted: 0,
+      totalPointsAwarded: 0,
+      completed: [],
+    });
+    expect(kpis).toEqual({
+      participantCount: 0,
+      totalMatches: 0,
+      completedMatches: 0,
+      predictionsSubmitted: 0,
+      totalPointsAwarded: 0,
+      avgPointsPerPrediction: 0,
+      exactRate: 0,
+    });
+  });
+
+  it("counts completed matches and computes averages and exact rate", () => {
+    // Match A 2-1: predictions [2-1 exact, 1-0 (winner only)]
+    // Match B 0-0: predictions [0-0 exact, 1-1 (winner only, draw)]
+    const completed = [group("a", 2, 1, [p(2, 1), p(1, 0)]), group("b", 0, 0, [p(0, 0), p(1, 1)])];
+    const kpis = computeOverviewKpis({
+      participantCount: 5,
+      totalMatches: 10,
+      predictionsSubmitted: 4,
+      totalPointsAwarded: 8,
+      completed,
+    });
+    expect(kpis.completedMatches).toBe(2);
+    expect(kpis.predictionsSubmitted).toBe(4);
+    expect(kpis.avgPointsPerPrediction).toBe(2); // 8 / 4
+    expect(kpis.exactRate).toBe(50); // 2 exact of 4 predictions
+  });
+
+  it("ignores groups without a recorded result", () => {
+    const kpis = computeOverviewKpis({
+      participantCount: 1,
+      totalMatches: 2,
+      predictionsSubmitted: 1,
+      totalPointsAwarded: 0,
+      completed: [group("a", null, null, [p(1, 0)])],
+    });
+    expect(kpis.completedMatches).toBe(0);
+    expect(kpis.exactRate).toBe(0);
+  });
+});
+
+describe("computeTournamentAccuracy", () => {
+  it("classifies every prediction across matches", () => {
+    // Match 3-1:
+    //  3-1 exact (3), 2-0 winner+diff (2), 1-0 winner only (1), 0-2 miss (0)
+    const groups = [group("a", 3, 1, [p(3, 1), p(2, 0), p(1, 0), p(0, 2)])];
+    expect(computeTournamentAccuracy(groups)).toEqual({
+      exact: 1,
+      winnerDiff: 1,
+      winnerOnly: 1,
+      miss: 1,
+    });
+  });
+
+  it("skips matches without results", () => {
+    const groups = [group("a", null, null, [p(1, 0)])];
+    expect(computeTournamentAccuracy(groups)).toEqual({
+      exact: 0,
+      winnerDiff: 0,
+      winnerOnly: 0,
+      miss: 0,
+    });
+  });
+});
+
+describe("computeCrowdCalledRate", () => {
+  it("counts matches where the consensus outcome matched the result", () => {
+    // Match A 2-0 (home): crowd leans home (2 home, 1 away) -> called
+    // Match B 0-1 (away): crowd leans home (2 home, 1 away) -> missed
+    const groups = [
+      group("a", 2, 0, [p(1, 0), p(3, 1), p(0, 1)]),
+      group("b", 0, 1, [p(1, 0), p(2, 1), p(0, 2)]),
+    ];
+    const rate = computeCrowdCalledRate(groups);
+    expect(rate).toEqual({ called: 1, total: 2, percentage: 50 });
+  });
+
+  it("excludes matches with no predictions from the denominator", () => {
+    const groups = [group("a", 2, 0, []), group("b", 1, 0, [p(1, 0)])];
+    const rate = computeCrowdCalledRate(groups);
+    expect(rate).toEqual({ called: 1, total: 1, percentage: 100 });
+  });
+});
+
+describe("computeOutcomeBias", () => {
+  it("contrasts actual results with the crowd's predicted outcomes", () => {
+    // Two completed matches, both home wins (2-0, 1-0).
+    // Crowd predicted: match A all home, match B all away -> 50/50 predicted split.
+    const groups = [group("a", 2, 0, [p(2, 0), p(1, 0)]), group("b", 1, 0, [p(0, 1), p(0, 2)])];
+    const bias = computeOutcomeBias(groups);
+    expect(bias.actual.counts).toEqual({ home: 2, draw: 0, away: 0 });
+    expect(bias.actual.percentages.home).toBe(100);
+    expect(bias.predicted.counts).toEqual({ home: 2, draw: 0, away: 2 });
+    expect(bias.predicted.percentages).toEqual({ home: 50, draw: 0, away: 50 });
+    expect(bias.avgGoals.actualTotal).toBe(1.5); // (2 + 1) / 2
+    expect(bias.scorelines[0].count).toBeGreaterThan(0);
+  });
+
+  it("returns zeroed averages with no completed matches", () => {
+    const bias = computeOutcomeBias([]);
+    expect(bias.actual.total).toBe(0);
+    expect(bias.avgGoals.actualTotal).toBe(0);
+    expect(bias.avgGoals.predictedTotal).toBe(0);
+    expect(bias.scorelines).toEqual([]);
+  });
+});
+
+describe("computeMatchSuperlatives", () => {
+  it("ranks hardest, best-called, and upset matches", () => {
+    // easy 2-1: both nail exact (avg 3); consensus home = result, no upset.
+    // hard 0-2 (away): both predicted home (avg 0); consensus home 100% -> upset.
+    // mild 0-1 (away): 2/3 favoured home (avg 1); consensus home 67% -> upset.
+    const groups = [
+      group("easy", 2, 1, [p(2, 1), p(2, 1)]),
+      group("hard", 0, 2, [p(3, 0), p(2, 0)]),
+      group("mild", 0, 1, [p(1, 0), p(2, 1), p(0, 1)]),
+    ];
+    const result = computeMatchSuperlatives(groups, 3);
+
+    expect(result.bestCalled[0].match.id).toBe("easy");
+    expect(result.bestCalled[0].avgPoints).toBe(3);
+    expect(result.hardest[0].match.id).toBe("hard");
+    expect(result.hardest[0].avgPoints).toBe(0);
+
+    // Both wrong-consensus matches surface, strongest wrong lean first.
+    expect(result.upsets).toHaveLength(2);
+    expect(result.upsets[0].match.id).toBe("hard");
+    expect(result.upsets[0].consensusOutcome).toBe("home");
+    expect(result.upsets[0].actualOutcome).toBe("away");
+    expect(result.upsets[0].consensusPercentage).toBe(100);
+    expect(result.upsets[1].match.id).toBe("mild");
+  });
+
+  it("respects the limit and skips empty/unfinished matches", () => {
+    const groups = [
+      group("a", 1, 0, [p(1, 0)]),
+      group("b", 2, 0, [p(2, 0)]),
+      group("c", 0, 0, []),
+      group("d", null, null, [p(1, 1)]),
+    ];
+    const result = computeMatchSuperlatives(groups, 1);
+    expect(result.hardest).toHaveLength(1);
+    expect(result.bestCalled).toHaveLength(1);
+  });
+});

--- a/lib/utils/tournament-stats.ts
+++ b/lib/utils/tournament-stats.ts
@@ -1,0 +1,306 @@
+import { getBasePoints } from "@/lib/utils/scoring";
+import {
+  computeOutcomeOdds,
+  computeScoreDistribution,
+  getConsensusOutcome,
+  outcomeOf,
+  distributePercentages,
+  type Outcome,
+  type OutcomeOdds,
+  type PredictionLike,
+  type MatchResultLike,
+  type ScoreDistributionEntry,
+  type AccuracyBreakdown,
+} from "@/lib/utils/match-stats";
+
+/**
+ * Tournament-level statistics, aggregated across every completed match and its
+ * predictions. Each function reuses the per-match helpers in match-stats.ts, so
+ * the whole module is pure and runs client-side with no extra data fetching.
+ *
+ * Callers should pass only *completed* matches (home_score / away_score non-null);
+ * every function additionally guards against missing results so partial data is
+ * simply ignored rather than throwing.
+ */
+
+/** A completed match grouped with all predictions submitted for it. */
+export interface MatchStatGroup<M extends MatchResultLike = MatchResultLike> {
+  match: M;
+  predictions: PredictionLike[];
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/** True when a match has a recorded final score. */
+function hasResult(match: MatchResultLike): match is { home_score: number; away_score: number } {
+  return match.home_score !== null && match.away_score !== null;
+}
+
+/* ------------------------------- Overview KPIs ------------------------------ */
+
+export interface OverviewInput<M extends MatchResultLike> {
+  participantCount: number;
+  totalMatches: number;
+  /** Total predictions submitted across the whole tournament (all matches). */
+  predictionsSubmitted: number;
+  /** Sum of points_earned across all predictions (includes match multipliers). */
+  totalPointsAwarded: number;
+  /** Completed matches with their predictions, for accuracy-based KPIs. */
+  completed: MatchStatGroup<M>[];
+}
+
+export interface OverviewKpis {
+  participantCount: number;
+  totalMatches: number;
+  completedMatches: number;
+  predictionsSubmitted: number;
+  totalPointsAwarded: number;
+  /** Average points per prediction, rounded to one decimal. */
+  avgPointsPerPrediction: number;
+  /** Share of completed-match predictions that nailed the exact score (integer %). */
+  exactRate: number;
+}
+
+export function computeOverviewKpis<M extends MatchResultLike>(
+  input: OverviewInput<M>
+): OverviewKpis {
+  const completed = input.completed.filter((g) => hasResult(g.match));
+
+  let exact = 0;
+  let completedPredictions = 0;
+  for (const { match, predictions } of completed) {
+    for (const p of predictions) {
+      completedPredictions += 1;
+      const base = getBasePoints(
+        p.predicted_home_score,
+        p.predicted_away_score,
+        match.home_score as number,
+        match.away_score as number
+      );
+      if (base === 3) exact += 1;
+    }
+  }
+
+  return {
+    participantCount: input.participantCount,
+    totalMatches: input.totalMatches,
+    completedMatches: completed.length,
+    predictionsSubmitted: input.predictionsSubmitted,
+    totalPointsAwarded: input.totalPointsAwarded,
+    avgPointsPerPrediction:
+      input.predictionsSubmitted > 0
+        ? round1(input.totalPointsAwarded / input.predictionsSubmitted)
+        : 0,
+    exactRate: completedPredictions > 0 ? Math.round((exact / completedPredictions) * 100) : 0,
+  };
+}
+
+/* ----------------------------- Accuracy breakdown -------------------------- */
+
+/**
+ * Sum every completed-match prediction into the four scoring categories.
+ * Mirrors computeAccuracyBreakdown but across the whole tournament.
+ */
+export function computeTournamentAccuracy<M extends MatchResultLike>(
+  groups: MatchStatGroup<M>[]
+): AccuracyBreakdown {
+  const breakdown: AccuracyBreakdown = { exact: 0, winnerDiff: 0, winnerOnly: 0, miss: 0 };
+  for (const { match, predictions } of groups) {
+    if (!hasResult(match)) continue;
+    for (const p of predictions) {
+      const base = getBasePoints(
+        p.predicted_home_score,
+        p.predicted_away_score,
+        match.home_score,
+        match.away_score
+      );
+      if (base === 3) breakdown.exact += 1;
+      else if (base === 2) breakdown.winnerDiff += 1;
+      else if (base === 1) breakdown.winnerOnly += 1;
+      else breakdown.miss += 1;
+    }
+  }
+  return breakdown;
+}
+
+/* ----------------------------- Crowd called rate --------------------------- */
+
+export interface CrowdCalledRate {
+  /** Completed matches where the consensus outcome matched the result. */
+  called: number;
+  /** Completed matches that had at least one prediction (the denominator). */
+  total: number;
+  /** called / total as an integer percentage. */
+  percentage: number;
+}
+
+export function computeCrowdCalledRate<M extends MatchResultLike>(
+  groups: MatchStatGroup<M>[]
+): CrowdCalledRate {
+  let called = 0;
+  let total = 0;
+  for (const { match, predictions } of groups) {
+    if (!hasResult(match) || predictions.length === 0) continue;
+    total += 1;
+    const consensus = getConsensusOutcome(computeOutcomeOdds(predictions));
+    const actual = outcomeOf(match.home_score, match.away_score);
+    if (consensus === actual) called += 1;
+  }
+  return {
+    called,
+    total,
+    percentage: total > 0 ? Math.round((called / total) * 100) : 0,
+  };
+}
+
+/* ------------------------------ Results & bias ----------------------------- */
+
+export interface AvgGoals {
+  predictedHome: number;
+  predictedAway: number;
+  predictedTotal: number;
+  actualHome: number;
+  actualAway: number;
+  actualTotal: number;
+}
+
+export interface OutcomeBias {
+  /** Distribution of actual results across completed matches. */
+  actual: OutcomeOdds;
+  /** Distribution of the crowd's predicted outcomes across all those predictions. */
+  predicted: OutcomeOdds;
+  avgGoals: AvgGoals;
+  /** Most common *actual* scorelines, sorted by frequency. */
+  scorelines: ScoreDistributionEntry[];
+}
+
+export function computeOutcomeBias<M extends MatchResultLike>(
+  groups: MatchStatGroup<M>[]
+): OutcomeBias {
+  const completed = groups.filter((g) => hasResult(g.match));
+
+  // Actual outcome split across completed matches.
+  const actualCounts: Record<Outcome, number> = { home: 0, draw: 0, away: 0 };
+  let sumActualHome = 0;
+  let sumActualAway = 0;
+  // Reuse the scoreline grouping by feeding actual results in PredictionLike shape.
+  const actualAsPredictions: PredictionLike[] = [];
+  for (const { match } of completed) {
+    const home = match.home_score as number;
+    const away = match.away_score as number;
+    actualCounts[outcomeOf(home, away)] += 1;
+    sumActualHome += home;
+    sumActualAway += away;
+    actualAsPredictions.push({ predicted_home_score: home, predicted_away_score: away });
+  }
+  const [aHome, aDraw, aAway] = distributePercentages([
+    actualCounts.home,
+    actualCounts.draw,
+    actualCounts.away,
+  ]);
+
+  // Predicted outcome split across every completed-match prediction.
+  const allPredictions = completed.flatMap((g) => g.predictions);
+  const predicted = computeOutcomeOdds(allPredictions);
+
+  let sumPredHome = 0;
+  let sumPredAway = 0;
+  for (const p of allPredictions) {
+    sumPredHome += p.predicted_home_score;
+    sumPredAway += p.predicted_away_score;
+  }
+
+  const matchCount = completed.length;
+  const predCount = allPredictions.length;
+
+  return {
+    actual: {
+      counts: actualCounts,
+      percentages: { home: aHome, draw: aDraw, away: aAway },
+      total: matchCount,
+    },
+    predicted,
+    avgGoals: {
+      predictedHome: predCount > 0 ? round1(sumPredHome / predCount) : 0,
+      predictedAway: predCount > 0 ? round1(sumPredAway / predCount) : 0,
+      predictedTotal: predCount > 0 ? round1((sumPredHome + sumPredAway) / predCount) : 0,
+      actualHome: matchCount > 0 ? round1(sumActualHome / matchCount) : 0,
+      actualAway: matchCount > 0 ? round1(sumActualAway / matchCount) : 0,
+      actualTotal: matchCount > 0 ? round1((sumActualHome + sumActualAway) / matchCount) : 0,
+    },
+    scorelines: computeScoreDistribution(actualAsPredictions),
+  };
+}
+
+/* ----------------------------- Match superlatives -------------------------- */
+
+export interface MatchMetric<M> {
+  match: M;
+  /** Average base points (0-3, no multiplier) the crowd earned on this match. */
+  avgPoints: number;
+  predictionCount: number;
+}
+
+export interface UpsetMetric<M> {
+  match: M;
+  consensusOutcome: Outcome;
+  actualOutcome: Outcome;
+  /** The crowd's share (integer %) on the outcome they wrongly favoured. */
+  consensusPercentage: number;
+}
+
+export interface MatchSuperlatives<M> {
+  /** Lowest average points first — the matches the crowd struggled with most. */
+  hardest: MatchMetric<M>[];
+  /** Highest average points first — the matches the crowd nailed. */
+  bestCalled: MatchMetric<M>[];
+  /** Strongest wrong consensus first — surfaces underdog wins. */
+  upsets: UpsetMetric<M>[];
+}
+
+export function computeMatchSuperlatives<M extends MatchResultLike>(
+  groups: MatchStatGroup<M>[],
+  limit = 3
+): MatchSuperlatives<M> {
+  const metrics: MatchMetric<M>[] = [];
+  const upsets: UpsetMetric<M>[] = [];
+
+  for (const { match, predictions } of groups) {
+    if (!hasResult(match) || predictions.length === 0) continue;
+
+    const totalBase = predictions.reduce(
+      (sum, p) =>
+        sum +
+        getBasePoints(
+          p.predicted_home_score,
+          p.predicted_away_score,
+          match.home_score,
+          match.away_score
+        ),
+      0
+    );
+    metrics.push({
+      match,
+      avgPoints: round1(totalBase / predictions.length),
+      predictionCount: predictions.length,
+    });
+
+    const odds = computeOutcomeOdds(predictions);
+    const consensusOutcome = getConsensusOutcome(odds);
+    const actualOutcome = outcomeOf(match.home_score, match.away_score);
+    if (consensusOutcome !== null && consensusOutcome !== actualOutcome) {
+      upsets.push({
+        match,
+        consensusOutcome,
+        actualOutcome,
+        consensusPercentage: odds.percentages[consensusOutcome],
+      });
+    }
+  }
+
+  const hardest = [...metrics].sort((a, b) => a.avgPoints - b.avgPoints).slice(0, limit);
+  const bestCalled = [...metrics].sort((a, b) => b.avgPoints - a.avgPoints).slice(0, limit);
+  upsets.sort((a, b) => b.consensusPercentage - a.consensusPercentage);
+
+  return { hardest, bestCalled, upsets: upsets.slice(0, limit) };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,8 +31,11 @@
       "crowdCalled": "The crowd called {called} of {total} results correctly ({percentage}%)."
     },
     "results": {
+      "outcomesTitle": "Match outcomes",
+      "outcome": "Outcome",
       "actualTitle": "Actual results",
       "predictedTitle": "What the crowd predicted",
+      "predictionsShort": "predictions",
       "home": "Home wins",
       "draw": "Draws",
       "away": "Away wins",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,7 @@
     "title": "Tournament Insights",
     "subtitle": "How the crowd is doing across the whole tournament",
     "breadcrumb": "Insights",
+    "scopeNote": "All insights are based only on predictions for completed matches.",
     "predictions": "{count, plural, =1 {# prediction} other {# predictions}}",
     "matchesCount": "{count, plural, =1 {# match} other {# matches}}",
     "empty": {
@@ -64,11 +65,13 @@
     },
     "awards": {
       "leader": "Leader",
-      "mostExact": "Most exact scores",
-      "highestAccuracy": "Best hit rate",
-      "mostPredictions": "Most predictions",
+      "bottom": "Bottom of the barrel",
+      "clairvoyant": "Clairvoyant",
+      "highEarner": "High earner",
+      "stillAtPlay": "Still at play",
       "pointsValue": "{points} pts",
-      "exactValue": "{count, plural, =1 {# exact} other {# exact}}"
+      "correctValue": "{count, plural, =1 {# correct} other {# correct}}",
+      "avgValue": "{points} avg pts"
     }
   },
   "common": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,73 @@
 {
+  "insights": {
+    "title": "Tournament Insights",
+    "subtitle": "How the crowd is doing across the whole tournament",
+    "breadcrumb": "Insights",
+    "predictions": "{count, plural, =1 {# prediction} other {# predictions}}",
+    "matchesCount": "{count, plural, =1 {# match} other {# matches}}",
+    "empty": {
+      "title": "No insights yet",
+      "description": "Insights appear once matches have been played and scored."
+    },
+    "kpi": {
+      "participants": "Players",
+      "predictions": "Predictions",
+      "matchesScored": "Matches scored",
+      "totalPoints": "Points awarded",
+      "avgPoints": "Avg pts / prediction",
+      "exactRate": "Exact-score rate"
+    },
+    "tabs": {
+      "accuracy": "Accuracy",
+      "results": "Results",
+      "matches": "Matches",
+      "awards": "Awards"
+    },
+    "accuracy": {
+      "exact": "Exact score",
+      "winnerDiff": "Winner + difference",
+      "winnerOnly": "Winner only",
+      "miss": "Missed",
+      "crowdCalled": "The crowd called {called} of {total} results correctly ({percentage}%)."
+    },
+    "results": {
+      "actualTitle": "Actual results",
+      "predictedTitle": "What the crowd predicted",
+      "home": "Home wins",
+      "draw": "Draws",
+      "away": "Away wins",
+      "avgGoalsTitle": "Goals per match",
+      "goalsHome": "Home",
+      "goalsAway": "Away",
+      "goalsTotal": "Total",
+      "predicted": "Predicted",
+      "actual": "Actual",
+      "scorelinesTitle": "Most common scorelines",
+      "scoreline": "Scoreline",
+      "count": "Matches",
+      "share": "Share",
+      "mostCommon": "Most common",
+      "other": "Other",
+      "chartLabel": "Distribution of actual scorelines",
+      "totalShort": "matches"
+    },
+    "matches": {
+      "upsetsTitle": "Biggest upsets",
+      "hardestTitle": "Toughest to predict",
+      "bestCalledTitle": "Best called",
+      "avgPointsLabel": "{points} avg pts",
+      "crowdFavored": "{team} {percentage}%",
+      "none": "Nothing to show yet."
+    },
+    "awards": {
+      "leader": "Leader",
+      "mostExact": "Most exact scores",
+      "highestAccuracy": "Best hit rate",
+      "mostPredictions": "Most predictions",
+      "pointsValue": "{points} pts",
+      "exactValue": "{count, plural, =1 {# exact} other {# exact}}"
+    }
+  },
   "common": {
     "appName": "Quiniela",
     "vs": "vs",
@@ -279,6 +348,7 @@
       "myPredictions": "My Predictions",
       "fullRankings": "Full Rankings",
       "allMatches": "All Matches",
+      "insights": "Insights",
       "yourRank": "Your Rank",
       "totalPoints": "Total Points",
       "predictions": "Predictions",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,73 @@
 {
+  "insights": {
+    "title": "Análisis del Torneo",
+    "subtitle": "Cómo le va a la afición en todo el torneo",
+    "breadcrumb": "Análisis",
+    "predictions": "{count, plural, =1 {# pronóstico} other {# pronósticos}}",
+    "matchesCount": "{count, plural, =1 {# partido} other {# partidos}}",
+    "empty": {
+      "title": "Aún no hay análisis",
+      "description": "El análisis aparece cuando se hayan jugado y puntuado partidos."
+    },
+    "kpi": {
+      "participants": "Jugadores",
+      "predictions": "Pronósticos",
+      "matchesScored": "Partidos puntuados",
+      "totalPoints": "Puntos otorgados",
+      "avgPoints": "Pts / pronóstico",
+      "exactRate": "Tasa de acierto exacto"
+    },
+    "tabs": {
+      "accuracy": "Precisión",
+      "results": "Resultados",
+      "matches": "Partidos",
+      "awards": "Premios"
+    },
+    "accuracy": {
+      "exact": "Resultado exacto",
+      "winnerDiff": "Ganador + diferencia",
+      "winnerOnly": "Solo ganador",
+      "miss": "Fallado",
+      "crowdCalled": "La afición acertó {called} de {total} resultados ({percentage}%)."
+    },
+    "results": {
+      "actualTitle": "Resultados reales",
+      "predictedTitle": "Lo que pronosticó la afición",
+      "home": "Gana local",
+      "draw": "Empates",
+      "away": "Gana visitante",
+      "avgGoalsTitle": "Goles por partido",
+      "goalsHome": "Local",
+      "goalsAway": "Visitante",
+      "goalsTotal": "Total",
+      "predicted": "Pronosticado",
+      "actual": "Real",
+      "scorelinesTitle": "Marcadores más comunes",
+      "scoreline": "Marcador",
+      "count": "Partidos",
+      "share": "Porcentaje",
+      "mostCommon": "Más común",
+      "other": "Otros",
+      "chartLabel": "Distribución de los marcadores reales",
+      "totalShort": "partidos"
+    },
+    "matches": {
+      "upsetsTitle": "Mayores sorpresas",
+      "hardestTitle": "Más difíciles de predecir",
+      "bestCalledTitle": "Mejor acertados",
+      "avgPointsLabel": "{points} pts promedio",
+      "crowdFavored": "{team} {percentage}%",
+      "none": "Nada que mostrar todavía."
+    },
+    "awards": {
+      "leader": "Líder",
+      "mostExact": "Más resultados exactos",
+      "highestAccuracy": "Mejor tasa de acierto",
+      "mostPredictions": "Más pronósticos",
+      "pointsValue": "{points} pts",
+      "exactValue": "{count, plural, =1 {# exacto} other {# exactos}}"
+    }
+  },
   "common": {
     "appName": "Quiniela",
     "vs": "vs",
@@ -279,6 +348,7 @@
       "myPredictions": "Mis pronósticos",
       "fullRankings": "Clasificación Completa",
       "allMatches": "Todos los Partidos",
+      "insights": "Análisis",
       "yourRank": "Tu Posición",
       "totalPoints": "Puntos Totales",
       "predictions": "pronósticos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,6 +3,7 @@
     "title": "Análisis del Torneo",
     "subtitle": "Cómo le va a la afición en todo el torneo",
     "breadcrumb": "Análisis",
+    "scopeNote": "Todos los análisis se basan únicamente en pronósticos de partidos finalizados.",
     "predictions": "{count, plural, =1 {# pronóstico} other {# pronósticos}}",
     "matchesCount": "{count, plural, =1 {# partido} other {# partidos}}",
     "empty": {
@@ -64,11 +65,13 @@
     },
     "awards": {
       "leader": "Líder",
-      "mostExact": "Más resultados exactos",
-      "highestAccuracy": "Mejor tasa de acierto",
-      "mostPredictions": "Más pronósticos",
+      "bottom": "Farolillo rojo",
+      "clairvoyant": "Vidente",
+      "highEarner": "Más rentable",
+      "stillAtPlay": "Aún en juego",
       "pointsValue": "{points} pts",
-      "exactValue": "{count, plural, =1 {# exacto} other {# exactos}}"
+      "correctValue": "{count, plural, =1 {# acierto} other {# aciertos}}",
+      "avgValue": "{points} pts promedio"
     }
   },
   "common": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,8 +31,11 @@
       "crowdCalled": "La afición acertó {called} de {total} resultados ({percentage}%)."
     },
     "results": {
+      "outcomesTitle": "Desenlace de los partidos",
+      "outcome": "Desenlace",
       "actualTitle": "Resultados reales",
       "predictedTitle": "Lo que pronosticó la afición",
+      "predictionsShort": "pronósticos",
       "home": "Gana local",
       "draw": "Empates",
       "away": "Gana visitante",

--- a/types/database.ts
+++ b/types/database.ts
@@ -80,6 +80,7 @@ export interface TournamentRanking {
   user_id: string;
   tournament_id: string;
   total_points: number;
+  predictions_count: number;
   rank: number;
   // Note: This is now a computed view, not a table
   // created_at and updated_at are not available


### PR DESCRIPTION
## Summary

Adds an **Insights** button to the tournament dashboard that opens a new `[tournamentId]/insights` page summarizing the whole competition. Surfaces tournament-wide accuracy, result/crowd-bias patterns, match superlatives (incl. underdog upsets), and player awards — all derived from the same predictions/matches data already used elsewhere.

Layout: an always-visible KPI row plus four tabs (KPI row + tabs mirror the existing match statistics card pattern). Result-dependent stats are computed over **completed matches only**.

### Sections
- **Overview KPIs**: players, predictions submitted, matches scored/total, points awarded, avg points per prediction, exact-score rate.
- **Accuracy**: tournament-wide stacked bar (exact / winner+diff / winner-only / miss) + "crowd called X of Y results" rate.
- **Results & bias**: actual vs predicted outcome split, avg goals predicted-vs-actual, most common actual scorelines (donut).
- **Matches**: biggest upsets (strongest wrong consensus → underdog wins), toughest-to-predict, best-called — each links to the match detail.
- **Awards**: leader, most exact scores, best hit rate, most predictions.

## Implementation
- New `lib/utils/tournament-stats.ts` — pure aggregation that reuses the per-match helpers in `lib/utils/match-stats.ts`. Computed client-side (matches the existing convention; tournament scale is small).
- Extracted `ShareBreakdown` / `DistributionView` / `DonutChart` out of `match-statistics-card.tsx` into `components/stats/` so both the match card and the insights page share them (mechanical, no behavior change).
- New server page `app/(app)/(user)/[tournamentId]/insights/page.tsx` + client `components/tournaments/tournament-insights.tsx`.
- Added `insights` i18n namespace + `dashboard.insights` button label (EN + ES).
- Added `predictions_count` to the `TournamentRanking` type (the rankings view already returns it).

## Testing
- New `lib/utils/__tests__/tournament-stats.test.ts` (11 tests, all branches).
- Full suite green (216 tests), `tsc --noEmit` clean, ESLint clean, production build succeeds.
- Verified end-to-end in the running app against local Supabase: button → page navigation, all four tabs, KPI reconciliation, and Spanish localization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)