### PR TITLE
feat(rankings): consistent sorting across leaderboard cards

### DIFF
--- a/app/(app)/(user)/[tournamentId]/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { TournamentDashboard } from "@/components/tournaments/tournament-dashboard";
-import { getPublicUserDisplay } from "@/lib/utils/privacy";
+import { buildLeaderboard } from "@/lib/utils/leaderboard";
+import { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
 import { notFound } from "next/navigation";
 
 export default async function TournamentPage({
@@ -48,20 +49,28 @@ export default async function TournamentPage({
       user:users(*)
     `
     )
-    .eq("tournament_id", tournamentId)
-    .order("rank", { ascending: true });
+    .eq("tournament_id", tournamentId);
 
-  // Sort: highest points -> alphabetical by display name (deterministic tie-break)
-  const sortedRankings = (rankings || [])
-    .slice()
-    .sort(
-      (a, b) =>
-        b.total_points - a.total_points ||
-        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
-    );
+  // Accuracy breakdown powers the shared leaderboard tie-breakers.
+  const { data: breakdownData } = await supabase
+    .from("tournament_prediction_breakdown")
+    .select(
+      `
+      *,
+      user:users(id, screen_name, avatar_url, created_at, updated_at)
+    `
+    )
+    .eq("tournament_id", tournamentId);
 
-  // Get user stats
-  const userRanking = rankings?.find((r) => r.user_id === user?.id);
+  // Sort consistently with the rankings page: points -> exact -> winner+goal
+  // diff -> winner, with tied participants sharing a rank.
+  const { rankings: sortedRankings } = buildLeaderboard(
+    (rankings || []) as RankingWithPublicUser[],
+    (breakdownData || []) as BreakdownWithPublicUser[]
+  );
+
+  // Get user stats from the consistently-ranked standings
+  const userRanking = sortedRankings.find((r) => r.user_id === user?.id);
 
   // Count user's predictions for this tournament
   const matchIds = matches?.map((m) => m.id) || [];

--- a/app/(app)/(user)/[tournamentId]/rankings/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { RankingsTabs } from "@/components/rankings/rankings-tabs";
 import { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
-import { getPublicUserDisplay } from "@/lib/utils/privacy";
+import { buildLeaderboard } from "@/lib/utils/leaderboard";
 import { BackButton } from "@/components/layout/back-button";
 import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
 import { getTranslations } from "next-intl/server";
@@ -38,17 +38,7 @@ export default async function RankingsPage({
       user:users(id, screen_name, avatar_url, created_at, updated_at)
     `
     )
-    .eq("tournament_id", tournamentId)
-    .order("rank", { ascending: true });
-
-  // Sort: highest points -> alphabetical by display name (deterministic tie-break)
-  const sortedRankings = ((rankings || []) as RankingWithPublicUser[])
-    .slice()
-    .sort(
-      (a, b) =>
-        b.total_points - a.total_points ||
-        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
-    );
+    .eq("tournament_id", tournamentId);
 
   const { data: breakdownData } = await supabase
     .from("tournament_prediction_breakdown")
@@ -60,16 +50,12 @@ export default async function RankingsPage({
     )
     .eq("tournament_id", tournamentId);
 
-  // Sort: most exact -> most goal-diff -> most winner -> alphabetical by display name
-  const breakdown = ((breakdownData || []) as BreakdownWithPublicUser[])
-    .slice()
-    .sort(
-      (a, b) =>
-        b.exact_count - a.exact_count ||
-        b.goal_diff_count - a.goal_diff_count ||
-        b.winner_count - a.winner_count ||
-        getPublicUserDisplay(a.user).localeCompare(getPublicUserDisplay(b.user))
-    );
+  // Sort both cards consistently: points -> exact -> winner+goal diff -> winner,
+  // with tied participants sharing a rank.
+  const { rankings: sortedRankings, breakdown } = buildLeaderboard(
+    (rankings || []) as RankingWithPublicUser[],
+    (breakdownData || []) as BreakdownWithPublicUser[]
+  );
 
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">

--- a/components/rankings/breakdown-table.tsx
+++ b/components/rankings/breakdown-table.tsx
@@ -3,15 +3,15 @@
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { BreakdownWithPublicUser } from "@/types/database";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
 import { getPodiumStyle, getRankColor } from "@/components/rankings/podium";
+import { RankedBreakdown } from "@/lib/utils/leaderboard";
 
 interface BreakdownTableProps {
-  breakdown: BreakdownWithPublicUser[];
+  breakdown: RankedBreakdown[];
   currentUserId?: string;
   tournamentId: string;
 }
@@ -60,9 +60,9 @@ export function BreakdownTable({ breakdown, currentUserId, tournamentId }: Break
               </tr>
             </thead>
             <tbody>
-              {breakdown.map((row, index) => {
+              {breakdown.map((row) => {
                 const isCurrentUser = row.user_id === currentUserId;
-                const position = index + 1;
+                const position = row.rank;
                 const href = `/${tournamentId}/rankings/${row.user_id}`;
 
                 return (

--- a/components/rankings/rankings-tabs.tsx
+++ b/components/rankings/rankings-tabs.tsx
@@ -4,11 +4,12 @@ import { useTranslations } from "next-intl";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RankingsTable } from "@/components/rankings/rankings-table";
 import { BreakdownTable } from "@/components/rankings/breakdown-table";
-import { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
+import { RankingWithPublicUser } from "@/types/database";
+import { RankedBreakdown } from "@/lib/utils/leaderboard";
 
 interface RankingsTabsProps {
   rankings: RankingWithPublicUser[];
-  breakdown: BreakdownWithPublicUser[];
+  breakdown: RankedBreakdown[];
   currentUserId?: string;
   tournamentId: string;
 }

--- a/lib/utils/__tests__/leaderboard.test.ts
+++ b/lib/utils/__tests__/leaderboard.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  assignRanks,
+  buildLeaderboard,
+  compareLeaderboard,
+  type LeaderboardSortStats,
+} from "@/lib/utils/leaderboard";
+import type {
+  BreakdownWithPublicUser,
+  PublicUserProfile,
+  RankingWithPublicUser,
+} from "@/types/database";
+
+function makeUser(id: string): PublicUserProfile {
+  return {
+    id,
+    screen_name: `user-${id}`,
+    avatar_url: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeStats(overrides: Partial<LeaderboardSortStats> = {}): LeaderboardSortStats {
+  return {
+    total_points: 0,
+    exact_count: 0,
+    goal_diff_count: 0,
+    winner_count: 0,
+    ...overrides,
+  };
+}
+
+function makeRanking(
+  id: string,
+  overrides: Partial<RankingWithPublicUser> = {}
+): RankingWithPublicUser {
+  return {
+    user_id: id,
+    tournament_id: "t1",
+    total_points: 0,
+    predictions_count: 0,
+    rank: 0,
+    user: makeUser(id),
+    ...overrides,
+  };
+}
+
+function makeBreakdown(
+  id: string,
+  overrides: Partial<BreakdownWithPublicUser> = {}
+): BreakdownWithPublicUser {
+  return {
+    user_id: id,
+    tournament_id: "t1",
+    exact_count: 0,
+    goal_diff_count: 0,
+    winner_count: 0,
+    total_points: 0,
+    user: makeUser(id),
+    ...overrides,
+  };
+}
+
+describe("compareLeaderboard", () => {
+  it("orders by total points first", () => {
+    expect(
+      compareLeaderboard(makeStats({ total_points: 10 }), makeStats({ total_points: 5 }))
+    ).toBeLessThan(0);
+  });
+
+  it("breaks point ties by exact count", () => {
+    const a = makeStats({ total_points: 10, exact_count: 3 });
+    const b = makeStats({ total_points: 10, exact_count: 5 });
+    expect(compareLeaderboard(a, b)).toBeGreaterThan(0);
+  });
+
+  it("breaks exact ties by winner + goal difference count", () => {
+    const a = makeStats({ total_points: 10, exact_count: 3, goal_diff_count: 1 });
+    const b = makeStats({ total_points: 10, exact_count: 3, goal_diff_count: 4 });
+    expect(compareLeaderboard(a, b)).toBeGreaterThan(0);
+  });
+
+  it("breaks goal-difference ties by winner count", () => {
+    const a = makeStats({ total_points: 10, exact_count: 3, goal_diff_count: 1, winner_count: 2 });
+    const b = makeStats({ total_points: 10, exact_count: 3, goal_diff_count: 1, winner_count: 6 });
+    expect(compareLeaderboard(a, b)).toBeGreaterThan(0);
+  });
+
+  it("returns 0 when every criterion is equal", () => {
+    const stats = makeStats({ total_points: 10, exact_count: 3, goal_diff_count: 1, winner_count: 2 });
+    expect(compareLeaderboard(stats, { ...stats })).toBe(0);
+  });
+});
+
+describe("assignRanks", () => {
+  it("sorts by the criteria and numbers ranks sequentially", () => {
+    const items = [
+      makeStats({ total_points: 5 }),
+      makeStats({ total_points: 10 }),
+      makeStats({ total_points: 7 }),
+    ];
+
+    const ranked = assignRanks(items, (s) => s);
+
+    expect(ranked.map((r) => [r.total_points, r.rank])).toEqual([
+      [10, 1],
+      [7, 2],
+      [5, 3],
+    ]);
+  });
+
+  it("gives tied entries the same rank and skips the next position", () => {
+    const items = [
+      makeStats({ total_points: 10, exact_count: 2 }),
+      makeStats({ total_points: 10, exact_count: 2 }),
+      makeStats({ total_points: 4 }),
+    ];
+
+    const ranked = assignRanks(items, (s) => s);
+
+    expect(ranked.map((r) => r.rank)).toEqual([1, 1, 3]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [makeStats({ total_points: 1 }), makeStats({ total_points: 9 })];
+    const snapshot = items.map((i) => i.total_points);
+
+    assignRanks(items, (s) => s);
+
+    expect(items.map((i) => i.total_points)).toEqual(snapshot);
+  });
+});
+
+describe("buildLeaderboard", () => {
+  it("ranks both cards consistently using breakdown counts as tie-breakers", () => {
+    // a and b are tied on points; a wins on exact count.
+    const rankings = [
+      makeRanking("a", { total_points: 10, rank: 99 }),
+      makeRanking("b", { total_points: 10, rank: 99 }),
+      makeRanking("c", { total_points: 3, rank: 99 }),
+    ];
+    const breakdown = [
+      makeBreakdown("a", { total_points: 10, exact_count: 3 }),
+      makeBreakdown("b", { total_points: 10, exact_count: 1 }),
+      makeBreakdown("c", { total_points: 3, winner_count: 3 }),
+    ];
+
+    const result = buildLeaderboard(rankings, breakdown);
+
+    expect(result.rankings.map((r) => [r.user_id, r.rank])).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+    expect(result.breakdown.map((r) => [r.user_id, r.rank])).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+  });
+
+  it("lets fully tied participants share a rank in both cards", () => {
+    const rankings = [
+      makeRanking("a", { total_points: 8 }),
+      makeRanking("b", { total_points: 8 }),
+    ];
+    const breakdown = [
+      makeBreakdown("a", { total_points: 8, exact_count: 2, goal_diff_count: 1, winner_count: 1 }),
+      makeBreakdown("b", { total_points: 8, exact_count: 2, goal_diff_count: 1, winner_count: 1 }),
+    ];
+
+    const result = buildLeaderboard(rankings, breakdown);
+
+    expect(result.rankings.map((r) => r.rank)).toEqual([1, 1]);
+    expect(result.breakdown.map((r) => r.rank)).toEqual([1, 1]);
+  });
+
+  it("treats a ranking with no matching breakdown row as zero counts", () => {
+    const rankings = [
+      makeRanking("a", { total_points: 5 }),
+      makeRanking("b", { total_points: 5 }),
+    ];
+    // Only 'b' has accuracy counts; 'a' falls back to zeros and ranks below.
+    const breakdown = [makeBreakdown("b", { total_points: 5, exact_count: 1 })];
+
+    const result = buildLeaderboard(rankings, breakdown);
+
+    expect(result.rankings.map((r) => [r.user_id, r.rank])).toEqual([
+      ["b", 1],
+      ["a", 2],
+    ]);
+  });
+});

--- a/lib/utils/leaderboard.ts
+++ b/lib/utils/leaderboard.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared leaderboard sorting used by both the overall leaderboard card and the
+ * accuracy breakdown card, so every standing is ordered the same way.
+ *
+ * Ranking criteria, in order:
+ *   1. Most total points
+ *   2. Most exact scores
+ *   3. Most correct winner + goal difference
+ *   4. Most correct winner
+ *
+ * Participants that remain tied after all four criteria share the same rank
+ * (standard competition ranking, e.g. 1, 2, 2, 4).
+ */
+
+import type { BreakdownWithPublicUser, RankingWithPublicUser } from "@/types/database";
+
+export interface LeaderboardSortStats {
+  total_points: number;
+  exact_count: number;
+  goal_diff_count: number;
+  winner_count: number;
+}
+
+/** Breakdown row enriched with its computed shared rank. */
+export type RankedBreakdown = BreakdownWithPublicUser & { rank: number };
+
+/**
+ * Comparator implementing the leaderboard criteria. Returns a negative number
+ * when `a` should rank ahead of `b`. A return of `0` means a perfect tie across
+ * every criterion (the two share a position).
+ */
+export function compareLeaderboard(a: LeaderboardSortStats, b: LeaderboardSortStats): number {
+  return (
+    b.total_points - a.total_points ||
+    b.exact_count - a.exact_count ||
+    b.goal_diff_count - a.goal_diff_count ||
+    b.winner_count - a.winner_count
+  );
+}
+
+/**
+ * Sort `items` by the leaderboard criteria and attach a shared `rank`. Tied
+ * entries receive the same rank and the next distinct entry skips ahead
+ * (1, 2, 2, 4). The original array is not mutated.
+ */
+export function assignRanks<T>(
+  items: T[],
+  stats: (item: T) => LeaderboardSortStats
+): (T & { rank: number })[] {
+  const sorted = items.slice().sort((a, b) => compareLeaderboard(stats(a), stats(b)));
+
+  let currentRank = 0;
+  return sorted.map((item, index) => {
+    if (index === 0 || compareLeaderboard(stats(sorted[index - 1]), stats(item)) !== 0) {
+      currentRank = index + 1;
+    }
+    return { ...item, rank: currentRank };
+  });
+}
+
+/**
+ * Produce consistently-sorted standings for both leaderboard cards. The overall
+ * rankings are enriched with each player's accuracy counts (from the breakdown)
+ * so both lists order — and rank — identical players identically.
+ */
+export function buildLeaderboard(
+  rankings: RankingWithPublicUser[],
+  breakdown: BreakdownWithPublicUser[]
+): { rankings: RankingWithPublicUser[]; breakdown: RankedBreakdown[] } {
+  const countsByUser = new Map(breakdown.map((b) => [b.user_id, b] as const));
+
+  const statsForRanking = (r: RankingWithPublicUser): LeaderboardSortStats => {
+    const counts = countsByUser.get(r.user_id);
+    return {
+      total_points: r.total_points,
+      exact_count: counts?.exact_count ?? 0,
+      goal_diff_count: counts?.goal_diff_count ?? 0,
+      winner_count: counts?.winner_count ?? 0,
+    };
+  };
+
+  return {
+    rankings: assignRanks(rankings, statsForRanking),
+    breakdown: assignRanks(breakdown, (b) => b),
+  };
+}


### PR DESCRIPTION
## Summary

Makes the two leaderboard cards sort by the **same** criteria, with tied participants sharing a rank.

Both the **overall leaderboard** and the **accuracy breakdown** now order by:

1. Most total points
2. Most exact scores
3. Most correct winner + goal difference
4. Most correct winner

Participants still tied after all four criteria **share** the same rank (standard competition ranking, e.g. `1, 2, 2, 4`).

### Why

Previously the cards used inconsistent rules:

- **Overall leaderboard** sorted by points only (alphabetical tie-break), never considering accuracy counts, and gave tied players distinct positions.
- **Breakdown** sorted by exact → goal-diff → winner but **ignored total points entirely**, and used the row index for position (no shared ranks).

So the same two players could appear in a different order on each tab.

## Changes

- Add `lib/utils/leaderboard.ts` — single source of truth for ordering:
  - `compareLeaderboard` — the criteria comparator
  - `assignRanks` — sorts and attaches shared competition ranks
  - `buildLeaderboard` — enriches the overall rankings with each player's accuracy counts (from the breakdown view) so both cards rank identical players identically
- `rankings/page.tsx` calls `buildLeaderboard` instead of two separate ad-hoc sorts
- `breakdown-table.tsx` renders the shared `rank` instead of `index + 1`
- `rankings-tabs.tsx` / breakdown table use the new `RankedBreakdown` type

> Note: the alphabetical tie-break was intentionally dropped — fully tied participants now share a position rather than being ordered further.

## Testing

- 11 new unit tests in `lib/utils/__tests__/leaderboard.test.ts` cover the comparator, each tie-break level, shared ranks, no-mutation, and the missing-breakdown-row fallback — all passing
- ESLint clean on touched files
- Verified locally against the seeded local Supabase stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)