### PR TITLE
feat(rankings): add head-to-head compare on the leaderboard

### DIFF
--- a/app/(app)/(user)/[tournamentId]/rankings/compare/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/compare/page.tsx
@@ -1,0 +1,164 @@
+import { createClient } from "@/lib/supabase/server";
+import { notFound, redirect } from "next/navigation";
+import { BackButton } from "@/components/layout/back-button";
+import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
+import { CompareSelector } from "@/components/rankings/compare-selector";
+import { ComparisonView, type ComparisonSide } from "@/components/rankings/comparison-view";
+import { buildLeaderboard } from "@/lib/utils/leaderboard";
+import {
+  BreakdownWithPublicUser,
+  PredictionWithMatch,
+  PublicUserProfile,
+  RankingWithPublicUser,
+} from "@/types/database";
+import { getTranslations } from "next-intl/server";
+
+const PREDICTIONS_WITH_MATCH = `
+  *,
+  match:matches!inner(
+    *,
+    home_team:teams!matches_home_team_id_fkey(*),
+    away_team:teams!matches_away_team_id_fkey(*)
+  )
+`;
+
+/** Fetch a user's completed-match predictions for a tournament (most recent first). */
+async function fetchCompletedPredictions(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  tournamentId: string,
+  userId: string
+): Promise<PredictionWithMatch[]> {
+  const { data } = await supabase
+    .from("predictions")
+    .select(PREDICTIONS_WITH_MATCH)
+    .eq("match.tournament_id", tournamentId)
+    .eq("match.status", "completed")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  return (data ?? []) as PredictionWithMatch[];
+}
+
+export default async function CompareRankingsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ tournamentId: string }>;
+  searchParams: Promise<{ opponent?: string }>;
+}) {
+  const t = await getTranslations("rankings");
+  const tCompare = await getTranslations("rankings.compare");
+  const { tournamentId } = await params;
+  const { opponent: opponentId } = await searchParams;
+  const supabase = await createClient();
+
+  const {
+    data: { user: currentUser },
+  } = await supabase.auth.getUser();
+
+  if (!currentUser) {
+    redirect("/login");
+  }
+
+  const { data: tournament } = await supabase
+    .from("tournaments")
+    .select("*")
+    .eq("id", tournamentId)
+    .single();
+
+  if (!tournament) {
+    notFound();
+  }
+
+  // Leaderboard pipeline (mirrors rankings/page.tsx) — used for the opponent
+  // picker and for each side's summary stats and rank.
+  const { data: rankings } = await supabase
+    .from("tournament_rankings")
+    .select(`*, user:users(id, screen_name, avatar_url, created_at, updated_at)`)
+    .eq("tournament_id", tournamentId);
+
+  const { data: breakdownData } = await supabase
+    .from("tournament_prediction_breakdown")
+    .select(`*, user:users(id, screen_name, avatar_url, created_at, updated_at)`)
+    .eq("tournament_id", tournamentId);
+
+  const { rankings: sortedRankings, breakdown } = buildLeaderboard(
+    (rankings || []) as RankingWithPublicUser[],
+    (breakdownData || []) as BreakdownWithPublicUser[]
+  );
+
+  const rankingByUser = new Map(sortedRankings.map((r) => [r.user_id, r]));
+  const breakdownByUser = new Map(breakdown.map((b) => [b.user_id, b]));
+
+  const opponentRanking = opponentId ? rankingByUser.get(opponentId) : undefined;
+  const isValidOpponent = !!opponentRanking && opponentId !== currentUser.id;
+
+  // Build one comparison side from the leaderboard maps + completed predictions.
+  async function buildSide(
+    userId: string,
+    user: PublicUserProfile
+  ): Promise<ComparisonSide> {
+    const ranking = rankingByUser.get(userId);
+    const counts = breakdownByUser.get(userId);
+    return {
+      user,
+      rank: ranking?.rank ?? null,
+      totalPoints: ranking?.total_points ?? 0,
+      exactCount: counts?.exact_count ?? 0,
+      goalDiffCount: counts?.goal_diff_count ?? 0,
+      winnerCount: counts?.winner_count ?? 0,
+      predictions: await fetchCompletedPredictions(supabase, tournamentId, userId),
+    };
+  }
+
+  let you: ComparisonSide | null = null;
+  let opponent: ComparisonSide | null = null;
+
+  if (isValidOpponent && opponentRanking) {
+    // The current user's own public profile (may not be in the leaderboard if
+    // they have no predictions yet, so fetch it explicitly).
+    const { data: currentProfile } = await supabase
+      .from("users")
+      .select("id, screen_name, avatar_url, created_at, updated_at")
+      .eq("id", currentUser.id)
+      .single();
+
+    if (currentProfile) {
+      you = await buildSide(currentUser.id, currentProfile as PublicUserProfile);
+      opponent = await buildSide(opponentId!, opponentRanking.user);
+    }
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-4xl">
+      <TournamentBreadcrumbs
+        tournamentId={tournamentId}
+        tournamentName={tournament.name}
+        items={[
+          { label: t("breadcrumb"), href: `/${tournamentId}/rankings` },
+          { label: tCompare("breadcrumb") },
+        ]}
+      />
+      <div className="mb-8 flex justify-between items-center">
+        <div>
+          <h1 className="text-4xl font-bold mb-2">{tCompare("title")}</h1>
+          <p className="text-muted-foreground">{tCompare("subtitle")}</p>
+        </div>
+        <BackButton fallbackHref={`/${tournamentId}/rankings`} />
+      </div>
+
+      <div className="space-y-6">
+        <CompareSelector
+          participants={sortedRankings}
+          currentUserId={currentUser.id}
+          selectedOpponentId={isValidOpponent ? opponentId : undefined}
+        />
+
+        {you && opponent ? (
+          <ComparisonView you={you} opponent={opponent} />
+        ) : (
+          <p className="text-muted-foreground">{tCompare("prompt")}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/(user)/[tournamentId]/rankings/page.tsx
+++ b/app/(app)/(user)/[tournamentId]/rankings/page.tsx
@@ -6,6 +6,9 @@ import { buildLeaderboard } from "@/lib/utils/leaderboard";
 import { comparePosition, type PositionChange } from "@/lib/utils/position-change";
 import { BackButton } from "@/components/layout/back-button";
 import { TournamentBreadcrumbs } from "@/components/layout/tournament-breadcrumbs";
+import { Button } from "@/components/ui/button";
+import { GitCompareArrows } from "lucide-react";
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 
 export default async function RankingsPage({
@@ -124,7 +127,13 @@ export default async function RankingsPage({
           <h1 className="text-4xl font-bold mb-2">{tournament?.name}</h1>
           <p className="text-muted-foreground">{t("subtitle")}</p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex shrink-0 gap-2">
+          <Link href={`/${tournamentId}/rankings/compare`}>
+            <Button variant="outline" className="animate-pulse-glow">
+              <GitCompareArrows className="h-4 w-4" aria-hidden="true" />
+              {t("compare.title")}
+            </Button>
+          </Link>
           <BackButton fallbackHref={`/${tournamentId}`} />
         </div>
       </div>

--- a/components/rankings/compare-selector.tsx
+++ b/components/rankings/compare-selector.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { RankingWithPublicUser } from "@/types/database";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getPublicUserDisplay } from "@/lib/utils/privacy";
+
+interface CompareSelectorProps {
+  /** Leaderboard rows used to populate the picker (current user is filtered out). */
+  participants: RankingWithPublicUser[];
+  currentUserId: string;
+  /** Currently selected opponent, if any. */
+  selectedOpponentId?: string;
+}
+
+/**
+ * Lets the current user pick a single opponent to compare against. Selecting an
+ * opponent navigates to `?opponent=<userId>` so the server component re-renders
+ * with securely-fetched, completed-match-only data.
+ */
+export function CompareSelector({
+  participants,
+  currentUserId,
+  selectedOpponentId,
+}: CompareSelectorProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const t = useTranslations("rankings.compare");
+
+  const opponents = participants.filter((p) => p.user_id !== currentUserId);
+
+  function handleSelect(opponentId: string) {
+    router.push(`${pathname}?opponent=${opponentId}`);
+  }
+
+  return (
+    <div className="max-w-sm">
+      <label htmlFor="compare-opponent" className="mb-2 block text-sm font-medium">
+        {t("selectLabel")}
+      </label>
+      <Select value={selectedOpponentId} onValueChange={handleSelect}>
+        <SelectTrigger id="compare-opponent" aria-label={t("selectLabel")}>
+          <SelectValue placeholder={t("selectPlaceholder")} />
+        </SelectTrigger>
+        <SelectContent>
+          {opponents.map((opponent) => (
+            <SelectItem key={opponent.user_id} value={opponent.user_id}>
+              {getPublicUserDisplay(opponent.user)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {opponents.length === 0 && (
+        <p className="mt-2 text-sm text-muted-foreground">{t("noOpponents")}</p>
+      )}
+    </div>
+  );
+}

--- a/components/rankings/compare-selector.tsx
+++ b/components/rankings/compare-selector.tsx
@@ -33,6 +33,7 @@ export function CompareSelector({
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations("rankings.compare");
+  const tCommon = useTranslations("common");
 
   const opponents = participants.filter((p) => p.user_id !== currentUserId);
 
@@ -52,7 +53,13 @@ export function CompareSelector({
         <SelectContent>
           {opponents.map((opponent) => (
             <SelectItem key={opponent.user_id} value={opponent.user_id}>
-              {getPublicUserDisplay(opponent.user)}
+              <span className="flex w-full items-center gap-2">
+                <span className="tabular-nums text-muted-foreground">#{opponent.rank}</span>
+                <span className="flex-1 truncate">{getPublicUserDisplay(opponent.user)}</span>
+                <span className="tabular-nums text-muted-foreground">
+                  {opponent.total_points} {tCommon("labels.pts")}
+                </span>
+              </span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/components/rankings/comparison-view.tsx
+++ b/components/rankings/comparison-view.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  PublicUserProfile,
+  PredictionWithMatch,
+  MatchWithTeams,
+} from "@/types/database";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { TeamBadge } from "@/components/teams/team-badge";
+import { formatLocalDateTime } from "@/lib/utils/date";
+import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
+import { computeHeadToHead } from "@/lib/utils/head-to-head";
+
+/** A participant's summary stats sourced from the leaderboard + breakdown. */
+export interface ComparisonSide {
+  user: PublicUserProfile;
+  rank: number | null;
+  totalPoints: number;
+  exactCount: number;
+  goalDiffCount: number;
+  winnerCount: number;
+  predictions: PredictionWithMatch[];
+}
+
+interface ComparisonViewProps {
+  you: ComparisonSide;
+  opponent: ComparisonSide;
+}
+
+/** Per-completed-match row joining both users' predictions by match. */
+interface ComparisonRow {
+  match: MatchWithTeams;
+  yourPrediction: PredictionWithMatch | null;
+  opponentPrediction: PredictionWithMatch | null;
+}
+
+export function ComparisonView({ you, opponent }: ComparisonViewProps) {
+  const t = useTranslations("rankings.compare");
+  const tCommon = useTranslations("common");
+
+  const headToHead = computeHeadToHead(you.predictions, opponent.predictions);
+
+  // Build a per-match join over every completed match either user predicted.
+  const rowsByMatch = new Map<string, ComparisonRow>();
+  for (const prediction of [...you.predictions, ...opponent.predictions]) {
+    if (prediction.match.status !== "completed") continue;
+    if (!rowsByMatch.has(prediction.match_id)) {
+      rowsByMatch.set(prediction.match_id, {
+        match: prediction.match,
+        yourPrediction: null,
+        opponentPrediction: null,
+      });
+    }
+  }
+  for (const prediction of you.predictions) {
+    const row = rowsByMatch.get(prediction.match_id);
+    if (row) row.yourPrediction = prediction;
+  }
+  for (const prediction of opponent.predictions) {
+    const row = rowsByMatch.get(prediction.match_id);
+    if (row) row.opponentPrediction = prediction;
+  }
+
+  const rows = Array.from(rowsByMatch.values()).sort(
+    (a, b) => new Date(b.match.match_date).getTime() - new Date(a.match.match_date).getTime()
+  );
+
+  const youName = getPublicUserDisplay(you.user);
+  const opponentName = getPublicUserDisplay(opponent.user);
+
+  return (
+    <div className="space-y-6">
+      {/* Summary stats, side by side */}
+      <div className="grid grid-cols-2 gap-4">
+        <SummaryCard side={you} isYou />
+        <SummaryCard side={opponent} />
+      </div>
+
+      {/* Head-to-head tally */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("headToHead.title")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {headToHead.total === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("headToHead.empty")}</p>
+          ) : (
+            <div className="grid grid-cols-3 gap-4 text-center">
+              <div>
+                <p className="text-3xl font-bold text-green-600 dark:text-green-400">
+                  {headToHead.youWon}
+                </p>
+                <p className="text-sm text-muted-foreground">{t("headToHead.youWon")}</p>
+              </div>
+              <div>
+                <p className="text-3xl font-bold text-muted-foreground">{headToHead.ties}</p>
+                <p className="text-sm text-muted-foreground">{t("headToHead.ties")}</p>
+              </div>
+              <div>
+                <p className="text-3xl font-bold">{headToHead.opponentWon}</p>
+                <p className="text-sm text-muted-foreground">{t("headToHead.opponentWon")}</p>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Match-by-match (completed only) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("matchByMatch.title")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("matchByMatch.empty")}</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wider text-muted-foreground">
+                    <th scope="col" className="py-2 pr-2 font-medium">
+                      {t("matchByMatch.match")}
+                    </th>
+                    <th scope="col" className="px-2 py-2 text-center font-medium">
+                      {t("matchByMatch.result")}
+                    </th>
+                    <th scope="col" className="px-2 py-2 text-center font-medium">
+                      {youName}
+                    </th>
+                    <th scope="col" className="px-2 py-2 text-center font-medium">
+                      {opponentName}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={row.match.id} className="border-b last:border-0">
+                      <td className="py-3 pr-2">
+                        <div className="flex items-center gap-2">
+                          <TeamBadge team={row.match.home_team} size="sm" showName={false} />
+                          <span className="text-xs text-muted-foreground">{tCommon("vs")}</span>
+                          <TeamBadge team={row.match.away_team} size="sm" showName={false} />
+                          {row.match.multiplier > 1 && (
+                            <Badge
+                              variant="outline"
+                              className="border-orange-500 text-orange-500"
+                            >
+                              {row.match.multiplier}x
+                            </Badge>
+                          )}
+                        </div>
+                        <span className="mt-1 block text-xs text-muted-foreground">
+                          {formatLocalDateTime(row.match.match_date)}
+                        </span>
+                      </td>
+                      <td className="px-2 py-3 text-center font-semibold whitespace-nowrap">
+                        {row.match.home_score} : {row.match.away_score}
+                      </td>
+                      <PredictionCell prediction={row.yourPrediction} match={row.match} />
+                      <PredictionCell prediction={row.opponentPrediction} match={row.match} />
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function SummaryCard({ side, isYou = false }: { side: ComparisonSide; isYou?: boolean }) {
+  const t = useTranslations("rankings");
+  const tCompare = useTranslations("rankings.compare");
+  const tCommon = useTranslations("common");
+
+  return (
+    <Card className={isYou ? "ring-2 ring-primary/30" : undefined}>
+      <CardContent className="space-y-4 pt-6">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-12 w-12">
+            <AvatarImage
+              src={side.user.avatar_url ?? undefined}
+              alt={getPublicUserDisplay(side.user)}
+            />
+            <AvatarFallback>{getPublicUserInitials(side.user)}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="truncate font-semibold">{getPublicUserDisplay(side.user)}</p>
+            {isYou && (
+              <span className="text-xs text-muted-foreground">{tCompare("you")}</span>
+            )}
+          </div>
+        </div>
+        <dl className="space-y-2 text-sm">
+          <StatRow label={t("rank")} value={side.rank != null ? `#${side.rank}` : "—"} />
+          <StatRow label={tCommon("labels.points")} value={side.totalPoints} />
+          <StatRow label={t("breakdown.exact")} value={side.exactCount} />
+          <StatRow label={t("breakdown.goalDiff")} value={side.goalDiffCount} />
+          <StatRow label={t("breakdown.winner")} value={side.winnerCount} />
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  );
+}
+
+function PredictionCell({
+  prediction,
+  match,
+}: {
+  prediction: PredictionWithMatch | null;
+  match: MatchWithTeams;
+}) {
+  if (!prediction) {
+    return <td className="px-2 py-3 text-center text-muted-foreground">—</td>;
+  }
+
+  const pointsClass =
+    prediction.points_earned >= 3 * match.multiplier
+      ? "bg-green-500"
+      : prediction.points_earned > 0
+        ? "bg-blue-500"
+        : "";
+
+  return (
+    <td className="px-2 py-3 text-center">
+      <div className="font-medium whitespace-nowrap">
+        {prediction.predicted_home_score} : {prediction.predicted_away_score}
+      </div>
+      <Badge
+        variant={prediction.points_earned > 0 ? "default" : "outline"}
+        className={`mt-1 ${pointsClass}`}
+      >
+        {prediction.points_earned}
+      </Badge>
+    </td>
+  );
+}

--- a/lib/utils/__tests__/head-to-head.test.ts
+++ b/lib/utils/__tests__/head-to-head.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { computeHeadToHead } from "../head-to-head";
+import type { MatchStatus, PredictionWithMatch } from "@/types/database";
+
+/** Build a minimal PredictionWithMatch for a given match/points/status. */
+function makePrediction(
+  matchId: string,
+  pointsEarned: number,
+  status: MatchStatus = "completed"
+): PredictionWithMatch {
+  return {
+    id: `pred-${matchId}`,
+    user_id: "user",
+    match_id: matchId,
+    predicted_home_score: 0,
+    predicted_away_score: 0,
+    points_earned: pointsEarned,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    match: {
+      id: matchId,
+      tournament_id: "tournament",
+      home_team_id: "home",
+      away_team_id: "away",
+      match_date: "2026-06-01T00:00:00Z",
+      home_score: 1,
+      away_score: 0,
+      status,
+      round: null,
+      multiplier: 1,
+      created_at: "2026-06-01T00:00:00Z",
+      updated_at: "2026-06-01T00:00:00Z",
+      // Teams are not used by the tally; cast through unknown to keep the fixture small.
+    } as PredictionWithMatch["match"],
+  };
+}
+
+describe("computeHeadToHead", () => {
+  it("counts a match where the current user scored higher as a win", () => {
+    const result = computeHeadToHead([makePrediction("m1", 3)], [makePrediction("m1", 1)]);
+    expect(result).toEqual({ youWon: 1, opponentWon: 0, ties: 0, total: 1 });
+  });
+
+  it("counts a match where the opponent scored higher as an opponent win", () => {
+    const result = computeHeadToHead([makePrediction("m1", 0)], [makePrediction("m1", 2)]);
+    expect(result).toEqual({ youWon: 0, opponentWon: 1, ties: 0, total: 1 });
+  });
+
+  it("counts equal points as a tie", () => {
+    const result = computeHeadToHead([makePrediction("m1", 2)], [makePrediction("m1", 2)]);
+    expect(result).toEqual({ youWon: 0, opponentWon: 0, ties: 1, total: 1 });
+  });
+
+  it("skips matches predicted by only one user", () => {
+    const result = computeHeadToHead(
+      [makePrediction("m1", 3), makePrediction("m2", 1)],
+      [makePrediction("m1", 1)]
+    );
+    expect(result).toEqual({ youWon: 1, opponentWon: 0, ties: 0, total: 1 });
+  });
+
+  it("ignores non-completed matches even if both users predicted them", () => {
+    const result = computeHeadToHead(
+      [makePrediction("m1", 0, "scheduled")],
+      [makePrediction("m1", 0, "scheduled")]
+    );
+    expect(result).toEqual({ youWon: 0, opponentWon: 0, ties: 0, total: 0 });
+  });
+
+  it("aggregates across multiple matches", () => {
+    const yours = [makePrediction("m1", 3), makePrediction("m2", 0), makePrediction("m3", 2)];
+    const theirs = [makePrediction("m1", 1), makePrediction("m2", 2), makePrediction("m3", 2)];
+    expect(computeHeadToHead(yours, theirs)).toEqual({
+      youWon: 1,
+      opponentWon: 1,
+      ties: 1,
+      total: 3,
+    });
+  });
+
+  it("returns an empty tally when there are no predictions", () => {
+    expect(computeHeadToHead([], [])).toEqual({
+      youWon: 0,
+      opponentWon: 0,
+      ties: 0,
+      total: 0,
+    });
+  });
+});

--- a/lib/utils/head-to-head.ts
+++ b/lib/utils/head-to-head.ts
@@ -1,0 +1,52 @@
+/**
+ * Head-to-head tally between the current user and a selected opponent.
+ *
+ * Only completed matches that BOTH users predicted count toward the tally, so a
+ * match where one side has no prediction is ignored (it isn't a fair contest).
+ * For each such match, whoever earned more `points_earned` "wins" that match;
+ * equal points is a tie.
+ */
+
+import type { PredictionWithMatch } from "@/types/database";
+
+export interface HeadToHeadResult {
+  /** Matches the current user scored higher than the opponent. */
+  youWon: number;
+  /** Matches the opponent scored higher than the current user. */
+  opponentWon: number;
+  /** Matches where both earned the same points. */
+  ties: number;
+  /** Completed matches both users predicted (youWon + opponentWon + ties). */
+  total: number;
+}
+
+/**
+ * Compute the head-to-head tally from each user's completed-match predictions.
+ * Both lists should already be limited to completed matches; matches present for
+ * only one user are skipped.
+ */
+export function computeHeadToHead(
+  yourPredictions: PredictionWithMatch[],
+  opponentPredictions: PredictionWithMatch[]
+): HeadToHeadResult {
+  const opponentByMatch = new Map(opponentPredictions.map((p) => [p.match_id, p]));
+
+  const result: HeadToHeadResult = { youWon: 0, opponentWon: 0, ties: 0, total: 0 };
+
+  for (const yours of yourPredictions) {
+    if (yours.match.status !== "completed") continue;
+    const theirs = opponentByMatch.get(yours.match_id);
+    if (!theirs || theirs.match.status !== "completed") continue;
+
+    result.total += 1;
+    if (yours.points_earned > theirs.points_earned) {
+      result.youWon += 1;
+    } else if (yours.points_earned < theirs.points_earned) {
+      result.opponentWon += 1;
+    } else {
+      result.ties += 1;
+    }
+  }
+
+  return result;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -687,6 +687,29 @@
       "pending": "Pending",
       "avgPointsPerMatch": "Avg Points/Match",
       "noPredictions": "No predictions have been submitted yet."
+    },
+    "compare": {
+      "title": "Compare",
+      "breadcrumb": "Compare",
+      "subtitle": "See how you stack up against another player",
+      "you": "You",
+      "selectLabel": "Compare against",
+      "selectPlaceholder": "Select a player",
+      "noOpponents": "There are no other players to compare with yet.",
+      "prompt": "Select a player above to see how you compare.",
+      "headToHead": {
+        "title": "Head-to-head",
+        "youWon": "You ahead",
+        "ties": "Ties",
+        "opponentWon": "They ahead",
+        "empty": "No completed matches predicted by both players yet."
+      },
+      "matchByMatch": {
+        "title": "Match by match",
+        "match": "Match",
+        "result": "Result",
+        "empty": "No completed matches to compare yet."
+      }
     }
   },
   "profile": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -687,6 +687,29 @@
       "pending": "Pendientes",
       "avgPointsPerMatch": "Promedio Puntos/Partido",
       "noPredictions": "Aún no se han enviado pronósticos."
+    },
+    "compare": {
+      "title": "Comparar",
+      "breadcrumb": "Comparar",
+      "subtitle": "Mira cómo te comparas con otro jugador",
+      "you": "Tú",
+      "selectLabel": "Comparar con",
+      "selectPlaceholder": "Selecciona un jugador",
+      "noOpponents": "Aún no hay otros jugadores con quien comparar.",
+      "prompt": "Selecciona un jugador arriba para ver la comparación.",
+      "headToHead": {
+        "title": "Mano a mano",
+        "youWon": "Vas por delante",
+        "ties": "Empates",
+        "opponentWon": "Va por delante",
+        "empty": "Aún no hay partidos completados pronosticados por ambos jugadores."
+      },
+      "matchByMatch": {
+        "title": "Partido por partido",
+        "match": "Partido",
+        "result": "Resultado",
+        "empty": "Aún no hay partidos completados para comparar."
+      }
     }
   },
   "profile": {

--- a/supabase/migrations/20260617000000_restrict_pending_predictions_visibility.sql
+++ b/supabase/migrations/20260617000000_restrict_pending_predictions_visibility.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- Restrict Pending Predictions Visibility
+-- ============================================================================
+-- Migration: 20260617000000_restrict_pending_predictions_visibility
+-- Created: 2026-06-17
+-- Description: Closes a privacy gap that let any authenticated user read every
+--   active user's predictions -- including predictions for matches that have
+--   NOT been completed yet (i.e. spying on other players' pending picks).
+--
+--   New SELECT policy: a user may read a prediction only when at least one of:
+--     - it is their own prediction, or
+--     - they are an admin, or
+--     - the owner is active AND the prediction's match is already 'completed'.
+--
+--   Safe for existing aggregates:
+--     - tournament_rankings (NOT security_invoker) is unaffected by RLS, and
+--       pending predictions contribute 0 points anyway, so totals/ranks are
+--       unchanged.
+--     - tournament_prediction_breakdown and its _previous view (security_invoker)
+--       already filter m.status = 'completed', so every row they read remains
+--       visible under the new policy.
+-- ============================================================================
+
+DROP POLICY IF EXISTS "Active users predictions are viewable" ON public.predictions;
+
+CREATE POLICY "Predictions viewable when own, admin, or match completed"
+  ON public.predictions FOR SELECT
+  USING (
+    auth.uid() = predictions.user_id
+    OR public.is_admin(auth.uid())
+    OR (
+      EXISTS (
+        SELECT 1 FROM public.users
+        WHERE users.id = predictions.user_id AND users.status = 'active'
+      )
+      AND EXISTS (
+        SELECT 1 FROM public.matches m
+        WHERE m.id = predictions.match_id AND m.status = 'completed'
+      )
+    )
+  );
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Summary

Adds a **Compare** feature to the tournament leaderboard: a user picks one other participant and sees a head-to-head comparison — side-by-side summary stats, a "who scored more" tally, and a match-by-match table — **limited to completed matches**.

While building it, this also closes a pre-existing privacy gap so the feature can't be used to spy on pending predictions.

## Security: pending predictions are now protected

The predictions `SELECT` RLS policy previously let **any authenticated user read every active user's predictions**, including picks for matches that hadn't been played yet. The existing `[userId]` detail page only hid pending predictions client-side, so they could be scraped directly.

New migration `20260617000000_restrict_pending_predictions_visibility.sql` restricts `SELECT` to:
- the user's own predictions, **or**
- admins, **or**
- other **active** users' predictions for matches that are already `completed`.

This is safe for existing aggregates:
- `tournament_rankings` is not `security_invoker` and pending predictions contribute 0 points → totals/ranks unchanged.
- `tournament_prediction_breakdown` (and its `_previous` view) already filter `m.status = 'completed'` → every row they read stays visible.

Verified directly against the local DB: player1 sees all their own predictions, only player2's **completed** prediction (3 pending hidden), and admin sees everything. Rankings/breakdown views return identical points/ranks under the new policy.

## What's included

- `/[tournamentId]/rankings/compare` server page (you vs. one selected player). Opponent predictions are fetched completed-only; RLS guarantees pending data never reaches the response.
- `compare-selector` (accessible opponent picker) and `comparison-view` (summary cards, head-to-head tally, semantic `<table>`), reusing existing leaderboard + prediction display patterns.
- `computeHeadToHead` util in `lib/utils/head-to-head.ts` (+ unit tests).
- A glowing **Compare** entry-point button on the rankings page (matches the Insights button style).
- New `rankings.compare.*` strings in `en.json` and `es.json`.

## Testing

- `npm run type-check`, `npm run lint`, `npm test` (236 tests, incl. 7 new head-to-head tests) — all green.
- Manual + Playwright walkthrough as player1 vs player2: only the single completed match appears; the 3 scheduled matches are excluded.

> [!NOTE]
> Includes a DB migration — run `npm run supabase:reset` (or apply the new migration) after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)