### PR TITLE
feat(matches): auto-reflect in-progress status and reveal predictions at kickoff

### DIFF
--- a/app/api/admin/matches/[matchId]/__tests__/route.test.ts
+++ b/app/api/admin/matches/[matchId]/__tests__/route.test.ts
@@ -5,49 +5,56 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockCheckAdminPermission = vi.hoisted(() => vi.fn());
 
-const { mockSupabase, matchesQb, matchesResult, tournamentTeamsQb, ttResult, predictionsQb, predictionsResult } =
-  vi.hoisted(() => {
-    function makeQb() {
-      const result = { data: null as unknown, error: null as unknown };
-      const qb: Record<string, ReturnType<typeof vi.fn>> = {
-        select: vi.fn(),
-        insert: vi.fn(),
-        update: vi.fn(),
-        delete: vi.fn(),
-        eq: vi.fn(),
-        neq: vi.fn(),
-        in: vi.fn(),
-        single: vi.fn(),
-        maybeSingle: vi.fn(),
-        limit: vi.fn(),
-        order: vi.fn(),
-      };
-      for (const key of Object.keys(qb)) {
-        if (key === "single" || key === "maybeSingle")
-          qb[key].mockImplementation(() => Promise.resolve(result));
-        else qb[key].mockReturnValue(qb);
-      }
-      Object.defineProperty(qb, "then", {
-        get: () => (resolve: (v: unknown) => void) => resolve(result),
-        configurable: true,
-      });
-      return { qb, result };
-    }
-
-    const { qb: matchesQb, result: matchesResult } = makeQb();
-    const { qb: tournamentTeamsQb, result: ttResult } = makeQb();
-    const { qb: predictionsQb, result: predictionsResult } = makeQb();
-
-    return {
-      mockSupabase: { from: vi.fn() },
-      matchesQb,
-      matchesResult,
-      tournamentTeamsQb,
-      ttResult,
-      predictionsQb,
-      predictionsResult,
+const {
+  mockSupabase,
+  matchesQb,
+  matchesResult,
+  tournamentTeamsQb,
+  ttResult,
+  predictionsQb,
+  predictionsResult,
+} = vi.hoisted(() => {
+  function makeQb() {
+    const result = { data: null as unknown, error: null as unknown };
+    const qb: Record<string, ReturnType<typeof vi.fn>> = {
+      select: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      eq: vi.fn(),
+      neq: vi.fn(),
+      in: vi.fn(),
+      single: vi.fn(),
+      maybeSingle: vi.fn(),
+      limit: vi.fn(),
+      order: vi.fn(),
     };
-  });
+    for (const key of Object.keys(qb)) {
+      if (key === "single" || key === "maybeSingle")
+        qb[key].mockImplementation(() => Promise.resolve(result));
+      else qb[key].mockReturnValue(qb);
+    }
+    Object.defineProperty(qb, "then", {
+      get: () => (resolve: (v: unknown) => void) => resolve(result),
+      configurable: true,
+    });
+    return { qb, result };
+  }
+
+  const { qb: matchesQb, result: matchesResult } = makeQb();
+  const { qb: tournamentTeamsQb, result: ttResult } = makeQb();
+  const { qb: predictionsQb, result: predictionsResult } = makeQb();
+
+  return {
+    mockSupabase: { from: vi.fn() },
+    matchesQb,
+    matchesResult,
+    tournamentTeamsQb,
+    ttResult,
+    predictionsQb,
+    predictionsResult,
+  };
+});
 
 vi.mock("@/lib/middleware/admin-check", () => ({
   checkAdminPermission: mockCheckAdminPermission,
@@ -125,6 +132,14 @@ describe("PUT /api/admin/matches/[matchId]", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toContain("different");
+  });
+
+  it("returns 400 when status is in_progress (deprecated, derived-only)", async () => {
+    const response = await PUT(makeRequest({ ...validBody, status: "in_progress" }), matchParams);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Status must be one of");
   });
 
   it("returns 400 for invalid multiplier", async () => {

--- a/app/api/admin/matches/[matchId]/route.ts
+++ b/app/api/admin/matches/[matchId]/route.ts
@@ -35,6 +35,14 @@ export async function PUT(
       return NextResponse.json({ error: "Home and away teams must be different" }, { status: 400 });
     }
 
+    // Validate status — "in_progress" is a derived, display-only state and cannot be stored
+    if (status !== undefined && !["scheduled", "completed", "cancelled"].includes(status)) {
+      return NextResponse.json(
+        { error: "Status must be one of: scheduled, completed, cancelled" },
+        { status: 400 }
+      );
+    }
+
     // Validate multiplier
     const multiplierNum = parseInt(multiplier);
     if (isNaN(multiplierNum) || multiplierNum < 1 || multiplierNum > 3) {

--- a/app/api/admin/matches/__tests__/route.test.ts
+++ b/app/api/admin/matches/__tests__/route.test.ts
@@ -130,6 +130,20 @@ describe("POST /api/admin/matches", () => {
     expect(body.error).toContain("Multiplier");
   });
 
+  it("returns 400 when status is in_progress (deprecated, derived-only)", async () => {
+    const response = await POST(makeRequest({ ...validBody, status: "in_progress" }));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Status must be one of");
+  });
+
+  it("returns 400 for an unknown status value", async () => {
+    const response = await POST(makeRequest({ ...validBody, status: "bogus" }));
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns 400 when teams are not both in the tournament", async () => {
     ttResult.data = [{ team_id: "team-1" }]; // only 1 of 2 found
 

--- a/app/api/admin/matches/route.ts
+++ b/app/api/admin/matches/route.ts
@@ -30,6 +30,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Home and away teams must be different" }, { status: 400 });
     }
 
+    // Validate status — "in_progress" is a derived, display-only state and cannot be stored
+    if (!["scheduled", "completed", "cancelled"].includes(status)) {
+      return NextResponse.json(
+        { error: "Status must be one of: scheduled, completed, cancelled" },
+        { status: 400 }
+      );
+    }
+
     // Validate multiplier
     const multiplierNum = parseInt(multiplier);
     if (isNaN(multiplierNum) || multiplierNum < 1 || multiplierNum > 3) {

--- a/app/api/predictions/__tests__/route.test.ts
+++ b/app/api/predictions/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import { createMockAuthUser } from "@/__tests__/helpers/supabase-mock";
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
 const mockCheckUserActive = vi.hoisted(() => vi.fn());
+const mockIsPastDate = vi.hoisted(() => vi.fn(() => false));
 
 const {
   mockSupabase,
@@ -78,6 +79,7 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/utils/date", () => ({
   getCurrentUTC: vi.fn(() => "2026-04-11T00:00:00.000Z"),
+  isPastDate: mockIsPastDate,
 }));
 
 // Import after mocking
@@ -108,6 +110,7 @@ describe("POST /api/predictions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCheckUserActive.mockResolvedValue(null);
+    mockIsPastDate.mockReturnValue(false);
     mockAuth.getUser.mockResolvedValue({
       data: { user: createMockAuthUser({ id: USER_ID }) },
       error: null,
@@ -117,7 +120,11 @@ describe("POST /api/predictions", () => {
       if (table === "tournament_participants") return participantsQb;
       return predictionsQb;
     });
-    matchesResult.data = { tournament_id: TOURNAMENT_ID, status: "scheduled" };
+    matchesResult.data = {
+      tournament_id: TOURNAMENT_ID,
+      status: "scheduled",
+      match_date: "2026-12-01T00:00:00.000Z",
+    };
     matchesResult.error = null;
     participantsResult.data = { user_id: USER_ID };
     participantsResult.error = null;
@@ -134,9 +141,7 @@ describe("POST /api/predictions", () => {
   // ── Input validation ───────────────────────────────────────────────────────
 
   it("returns 400 when match_id is missing", async () => {
-    const response = await POST(
-      makeRequest({ predicted_home_score: 1, predicted_away_score: 0 })
-    );
+    const response = await POST(makeRequest({ predicted_home_score: 1, predicted_away_score: 0 }));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toContain("match_id");
@@ -219,6 +224,16 @@ describe("POST /api/predictions", () => {
 
     const response = await POST(makeRequest(validBody));
     expect(response.status).toBe(422);
+  });
+
+  it("returns 422 when the match start time has passed (server-side time lock)", async () => {
+    // Status is still "scheduled" (never auto-advanced), but kickoff has passed.
+    mockIsPastDate.mockReturnValue(true);
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error).toContain("Predictions are closed");
   });
 
   it("returns 403 when user is not a tournament participant", async () => {

--- a/app/api/predictions/route.ts
+++ b/app/api/predictions/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
-import { getCurrentUTC } from "@/lib/utils/date";
+import { getCurrentUTC, isPastDate } from "@/lib/utils/date";
 import { checkUserActive } from "@/lib/middleware/user-status-check";
 
 export async function POST(request: NextRequest) {
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
     // Get the match to find the tournament_id and check it is open for predictions
     const { data: match, error: matchError } = await supabase
       .from("matches")
-      .select("tournament_id, status")
+      .select("tournament_id, status, match_date")
       .eq("id", match_id)
       .single();
 
@@ -52,11 +52,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Match not found" }, { status: 404 });
     }
 
-    if (match.status === "completed" || match.status === "cancelled") {
-      return NextResponse.json(
-        { error: "Predictions are closed for this match" },
-        { status: 422 }
-      );
+    // Predictions close once the match is finished/cancelled or its start time has passed.
+    // The time check is the server-side counterpart to the client lock and the source of
+    // truth for the derived "in_progress" state (status stays "scheduled" until scored).
+    if (
+      match.status === "completed" ||
+      match.status === "cancelled" ||
+      isPastDate(match.match_date)
+    ) {
+      return NextResponse.json({ error: "Predictions are closed for this match" }, { status: 422 });
     }
 
     // Check if user is a participant in this tournament

--- a/components/matches/management/match-create-form.tsx
+++ b/components/matches/management/match-create-form.tsx
@@ -159,7 +159,6 @@ export function MatchCreateForm({ tournamentId, teams }: MatchCreateFormProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="scheduled">{tStatus("scheduled")}</SelectItem>
-                  <SelectItem value="in_progress">{tStatus("inProgress")}</SelectItem>
                   <SelectItem value="completed">{tStatus("completed")}</SelectItem>
                   <SelectItem value="cancelled">{tStatus("cancelled")}</SelectItem>
                 </SelectContent>

--- a/components/matches/management/match-edit-form.tsx
+++ b/components/matches/management/match-edit-form.tsx
@@ -209,7 +209,6 @@ export function MatchEditForm({ match, teams }: MatchEditFormProps) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="scheduled">{tStatus("scheduled")}</SelectItem>
-                  <SelectItem value="in_progress">{tStatus("inProgress")}</SelectItem>
                   <SelectItem value="completed">{tStatus("completed")}</SelectItem>
                   <SelectItem value="cancelled">{tStatus("cancelled")}</SelectItem>
                 </SelectContent>

--- a/components/matches/management/match-management-list.tsx
+++ b/components/matches/management/match-management-list.tsx
@@ -112,7 +112,6 @@ export function MatchManagementList({ matches }: MatchManagementListProps) {
             <SelectContent>
               <SelectItem value="all">{tCommon("filters.allStatuses")}</SelectItem>
               <SelectItem value="scheduled">{t("status.scheduled")}</SelectItem>
-              <SelectItem value="in_progress">{t("status.in_progress")}</SelectItem>
               <SelectItem value="completed">{t("status.completed")}</SelectItem>
               <SelectItem value="cancelled">{t("status.cancelled")}</SelectItem>
             </SelectContent>

--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { TeamBadge } from "@/components/teams/team-badge";
 import { Badge } from "@/components/ui/badge";
 import { formatLocalDateTime } from "@/lib/utils/date";
+import { getEffectiveMatchStatus } from "@/lib/utils/match-status";
 import { Zap } from "lucide-react";
 import Link from "next/link";
 
@@ -16,8 +17,9 @@ interface MatchCardProps {
 export function MatchCard({ match }: MatchCardProps) {
   const t = useTranslations("matches.status");
   const tCommon = useTranslations("common");
-  const isCompleted = match.status === "completed";
-  const isLive = match.status === "in_progress";
+  const status = getEffectiveMatchStatus(match);
+  const isCompleted = status === "completed";
+  const isLive = status === "in_progress";
 
   const homeWins =
     isCompleted &&
@@ -56,14 +58,7 @@ export function MatchCard({ match }: MatchCardProps) {
                 variant={isLive ? "default" : "outline"}
                 className={isLive ? "bg-success animate-pulse-live" : ""}
               >
-                {t(
-                  match.status as
-                    | "scheduled"
-                    | "in_progress"
-                    | "completed"
-                    | "postponed"
-                    | "cancelled"
-                )}
+                {t(status)}
               </Badge>
             </div>
 

--- a/components/matches/match-detail-view.tsx
+++ b/components/matches/match-detail-view.tsx
@@ -7,6 +7,7 @@ import { MatchStatisticsCard } from "@/components/matches/match-statistics-card"
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatLocalDateTime } from "@/lib/utils/date";
+import { getEffectiveMatchStatus } from "@/lib/utils/match-status";
 import { Zap, Sparkles } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -23,12 +24,13 @@ interface MatchDetailViewProps {
 export function MatchDetailView({ match, predictions, currentUserId }: MatchDetailViewProps) {
   const t = useTranslations("matches");
   const tCommon = useTranslations("common");
-  const isCompleted = match.status === "completed";
-  const isLive = match.status === "in_progress";
-  const isCancelled = match.status === "cancelled";
+  const status = getEffectiveMatchStatus(match);
+  const isCompleted = status === "completed";
+  const isLive = status === "in_progress";
+  const isCancelled = status === "cancelled";
 
   const getStatusColor = () => {
-    switch (match.status) {
+    switch (status) {
       case "completed":
         return "bg-info";
       case "in_progress":
@@ -61,7 +63,7 @@ export function MatchDetailView({ match, predictions, currentUserId }: MatchDeta
               variant={isLive || isCompleted ? "default" : "outline"}
               className={`${getStatusColor()} ${isLive ? "animate-pulse-live" : ""}`}
             >
-              {t(`status.${match.status}`)}
+              {t(`status.${status}`)}
             </Badge>
           </div>
         </CardHeader>
@@ -195,7 +197,7 @@ function PredictionRow({
       .slice(0, 2);
   };
 
-  const isLive = match.status === "in_progress";
+  const isLive = getEffectiveMatchStatus(match) === "in_progress";
   const showPrediction = isLive || isCompleted || isCancelled || isCurrentUser;
   const showBreakdown =
     showPrediction && isCompleted && !isCancelled && prediction.points_earned > 0;

--- a/components/rankings/user-predictions-view.tsx
+++ b/components/rankings/user-predictions-view.tsx
@@ -12,6 +12,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { TeamBadge } from "@/components/teams/team-badge";
 import { formatLocalDateTime } from "@/lib/utils/date";
+import { getEffectiveMatchStatus } from "@/lib/utils/match-status";
 import { getPublicUserDisplay, getPublicUserInitials } from "@/lib/utils/privacy";
 import Link from "next/link";
 
@@ -134,7 +135,9 @@ export function UserPredictionsView({
                 <PredictionRow
                   key={prediction.id}
                   prediction={prediction}
-                  showDetails={isCurrentUser || prediction.match.status !== "scheduled"}
+                  showDetails={
+                    isCurrentUser || getEffectiveMatchStatus(prediction.match) !== "scheduled"
+                  }
                 />
               ))}
             </div>
@@ -165,9 +168,10 @@ function PredictionRow({ prediction, showDetails }: PredictionRowProps) {
   const tCommon = useTranslations("common");
 
   const match = prediction.match;
-  const isCompleted = match.status === "completed";
-  const isLive = match.status === "in_progress";
-  const isCancelled = match.status === "cancelled";
+  const status = getEffectiveMatchStatus(match);
+  const isCompleted = status === "completed";
+  const isLive = status === "in_progress";
+  const isCancelled = status === "cancelled";
 
   const getStatusBadge = () => {
     if (isCompleted) {

--- a/lib/utils/__tests__/match-status.test.ts
+++ b/lib/utils/__tests__/match-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getEffectiveMatchStatus } from "../match-status";
+
+const HOUR = 60 * 60 * 1000;
+const future = () => new Date(Date.now() + HOUR).toISOString();
+const past = () => new Date(Date.now() - HOUR).toISOString();
+
+describe("getEffectiveMatchStatus", () => {
+  it("keeps a scheduled match scheduled when start time is in the future", () => {
+    expect(getEffectiveMatchStatus({ status: "scheduled", match_date: future() })).toBe(
+      "scheduled"
+    );
+  });
+
+  it("derives in_progress for a scheduled match whose start time has passed", () => {
+    expect(getEffectiveMatchStatus({ status: "scheduled", match_date: past() })).toBe(
+      "in_progress"
+    );
+  });
+
+  it("passes through completed regardless of time", () => {
+    expect(getEffectiveMatchStatus({ status: "completed", match_date: past() })).toBe("completed");
+    expect(getEffectiveMatchStatus({ status: "completed", match_date: future() })).toBe(
+      "completed"
+    );
+  });
+
+  it("passes through cancelled regardless of time", () => {
+    expect(getEffectiveMatchStatus({ status: "cancelled", match_date: past() })).toBe("cancelled");
+    expect(getEffectiveMatchStatus({ status: "cancelled", match_date: future() })).toBe(
+      "cancelled"
+    );
+  });
+});

--- a/lib/utils/match-status.ts
+++ b/lib/utils/match-status.ts
@@ -1,0 +1,19 @@
+import { Match, MatchStatus } from "@/types/database";
+import { isPastDate } from "@/lib/utils/date";
+
+/**
+ * Effective, display-time match status.
+ *
+ * A "scheduled" match whose start time has passed is presented as "in_progress"
+ * without mutating the stored status. All other stored statuses pass through.
+ *
+ * "in_progress" is a derived, display-only state — it is never stored. See the
+ * tightened `matches_status_check` constraint, which only permits
+ * 'scheduled' | 'completed' | 'cancelled'.
+ */
+export function getEffectiveMatchStatus(match: Pick<Match, "status" | "match_date">): MatchStatus {
+  if (match.status === "scheduled" && isPastDate(match.match_date)) {
+    return "in_progress";
+  }
+  return match.status;
+}

--- a/supabase/migrations/20260622065918_tighten_match_status.sql
+++ b/supabase/migrations/20260622065918_tighten_match_status.sql
@@ -1,0 +1,14 @@
+-- Deprecate the stored "in_progress" match status.
+--
+-- "in_progress" is now a derived, display-time state: a match is shown as in-progress
+-- once its match_date has passed (see lib/utils/match-status.ts). It is no longer a value
+-- that admins set or that we persist. Tighten the CHECK constraint accordingly.
+
+-- Defensively map any pre-existing stored in_progress rows back to scheduled.
+-- The display layer will re-derive in_progress from match_date where appropriate.
+UPDATE matches SET status = 'scheduled' WHERE status = 'in_progress';
+
+-- Replace the inline CHECK constraint from the initial schema.
+ALTER TABLE matches DROP CONSTRAINT matches_status_check;
+ALTER TABLE matches ADD CONSTRAINT matches_status_check
+  CHECK (status IN ('scheduled', 'completed', 'cancelled'));

--- a/supabase/migrations/20260622070500_reveal_predictions_at_kickoff.sql
+++ b/supabase/migrations/20260622070500_reveal_predictions_at_kickoff.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- Reveal Predictions At Kickoff
+-- ============================================================================
+-- Migration: 20260622070500_reveal_predictions_at_kickoff
+-- Created: 2026-06-22
+-- Description: Predictions now become public to other participants once a match
+--   has started, not only once it is "completed". This mirrors the derived
+--   "in_progress" display state (a scheduled match whose match_date has passed)
+--   and the prediction lock, which both key off match_date — predictions can no
+--   longer change after kickoff, so revealing them is safe.
+--
+--   Updated SELECT policy: a user may read a prediction when at least one of:
+--     - it is their own prediction, or
+--     - they are an admin, or
+--     - the owner is active AND the prediction's match has started
+--       (status = 'completed' OR match_date <= now()).
+--
+--   "in_progress" is intentionally not referenced — it is a derived,
+--   display-only state and is never stored (see 20260622065918_tighten_match_status).
+--
+--   Safe for existing aggregates: tournament_rankings is not security_invoker and
+--   pending predictions contribute 0 points; the breakdown views still filter
+--   m.status = 'completed', a strict subset of the rows allowed here.
+-- ============================================================================
+
+DROP POLICY IF EXISTS "Predictions viewable when own, admin, or match completed" ON public.predictions;
+
+CREATE POLICY "Predictions viewable when own, admin, or match started"
+  ON public.predictions FOR SELECT
+  USING (
+    auth.uid() = predictions.user_id
+    OR public.is_admin(auth.uid())
+    OR (
+      EXISTS (
+        SELECT 1 FROM public.users
+        WHERE users.id = predictions.user_id AND users.status = 'active'
+      )
+      AND EXISTS (
+        SELECT 1 FROM public.matches m
+        WHERE m.id = predictions.match_id
+          AND (m.status = 'completed' OR m.match_date <= now())
+      )
+    )
+  );
+
+-- ============================================================================
+-- END OF MIGRATION
+-- ============================================================================


### PR DESCRIPTION
## Context

Today a match only shows as **in-progress** once an admin manually edits its status. Until then it reads "Scheduled" in the UI and every other participant's predictions stay hidden, making the experience depend on an admin acting at kickoff. This change makes the transition automatic and time-driven.

## What changed

**Derived status (display-only)**
- New `lib/utils/match-status.ts` — `getEffectiveMatchStatus(match)` maps a past-start `scheduled` match to `in_progress` at read time, without mutating the stored status. User-facing match displays (`match-card`, `match-detail-view`, `rankings/user-predictions-view`) route through it. Actual match scores stay hidden until `completed`; **scoring remains a manual admin step**.

**Reveal predictions at kickoff (RLS)**
- New migration updates the predictions SELECT policy so other active users' predictions become visible when `status = 'completed' OR match_date <= now()`. Predictions are locked at kickoff, so revealing them is safe. This mirrors the derived in-progress state. (The previous policy only revealed on `completed`, which would have left predictions hidden under the derive-only approach.)

**Server-side time guard**
- `POST /api/predictions` now rejects with 422 once `match_date` has passed — closing the gap where a crafted request could submit after kickoff while the stored status was still `scheduled` (previously only the client enforced this).

**Deprecate stored `in_progress`**
- Removed from the admin create/edit dropdowns and the management filter.
- Both admin match routes (`POST`/`PUT`) reject any status outside `scheduled/completed/cancelled` (400).
- Migration tightens the `matches.status` CHECK constraint to `('scheduled','completed','cancelled')`, mapping any stray rows back to `scheduled`.

Admin management views intentionally keep showing the **raw stored** status (admins manage the true value).

## Tests
- New `lib/utils/__tests__/match-status.test.ts`.
- Updated predictions + admin-matches route tests (server time-lock 422, deprecated-status 400). Full suite: 244 passing.

## Manual validation (local stack + Playwright)
- Past-start `scheduled` match → displays **In Progress**, all participants' predictions revealed, score area still shows "vs".
- Future `scheduled` match → stays **Scheduled**, others' predictions hidden.
- `POST /api/predictions` → 422 on started match, 200 on upcoming match.
- Admin edit dropdown lists only Scheduled/Completed/Cancelled; `PUT status:"in_progress"` → 400.

## Notes
- All `predictions` reads go through the RLS-bound client; the service-role client is only used for `users` reads/writes, so the RLS policy governs every prediction read path — no additional changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)